### PR TITLE
feat(deployment): Complete GitHub repository creation implementation (#3)

### DIFF
--- a/packages/backend/src/deployment/deployment.module.ts
+++ b/packages/backend/src/deployment/deployment.module.ts
@@ -10,6 +10,8 @@ import { DeploymentOrchestratorService } from './deployment.service';
 import { GitHubRepoProvider } from './providers/github-repo.provider';
 import { GistProvider } from './providers/gist.provider';
 import { DevContainerProvider } from './providers/devcontainer.provider';
+import { GitignoreProvider } from './providers/gitignore.provider';
+import { CIWorkflowProvider } from './providers/ci-workflow.provider';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Deployment, Conversation])],
@@ -19,6 +21,8 @@ import { DevContainerProvider } from './providers/devcontainer.provider';
     GitHubRepoProvider,
     GistProvider,
     DevContainerProvider,
+    GitignoreProvider,
+    CIWorkflowProvider,
   ],
   exports: [DeploymentOrchestratorService],
 })

--- a/packages/backend/src/deployment/deployment.service.spec.ts
+++ b/packages/backend/src/deployment/deployment.service.spec.ts
@@ -1,0 +1,343 @@
+/// <reference types="jest" />
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import { DeploymentOrchestratorService } from './deployment.service';
+import { Deployment } from '../database/entities/deployment.entity';
+import { Conversation } from '../database/entities/conversation.entity';
+import { GitHubRepoProvider } from './providers/github-repo.provider';
+import { GistProvider } from './providers/gist.provider';
+import { DevContainerProvider } from './providers/devcontainer.provider';
+import { GitignoreProvider } from './providers/gitignore.provider';
+import { CIWorkflowProvider } from './providers/ci-workflow.provider';
+
+describe('DeploymentOrchestratorService', () => {
+  let service: DeploymentOrchestratorService;
+  let mockDeploymentRepository: any;
+  let mockConversationRepository: any;
+  let mockGitHubRepoProvider: any;
+  let mockGistProvider: any;
+  let mockDevContainerProvider: any;
+  let mockGitignoreProvider: any;
+  let mockCIWorkflowProvider: any;
+
+  const mockConversation = {
+    id: 'conv-123',
+    state: { serverName: 'test-mcp-server' },
+  };
+
+  const mockDeployment = {
+    id: 'deploy-123',
+    conversationId: 'conv-123',
+    deploymentType: 'repo',
+    status: 'pending',
+    metadata: {},
+  };
+
+  beforeEach(async () => {
+    mockDeploymentRepository = {
+      create: jest.fn().mockReturnValue(mockDeployment),
+      save: jest.fn().mockResolvedValue(mockDeployment),
+      update: jest.fn().mockResolvedValue({}),
+      find: jest.fn().mockResolvedValue([mockDeployment]),
+      findOne: jest.fn().mockResolvedValue(mockDeployment),
+      findOneBy: jest.fn().mockResolvedValue(mockDeployment),
+    };
+
+    mockConversationRepository = {
+      findOneBy: jest.fn().mockResolvedValue(mockConversation),
+    };
+
+    mockGitHubRepoProvider = {
+      deploy: jest.fn().mockResolvedValue({
+        success: true,
+        repositoryUrl: 'https://github.com/test-user/test-repo',
+        cloneUrl: 'https://github.com/test-user/test-repo.git',
+        codespaceUrl: 'https://github.com/codespaces/new?repo=test-user/test-repo',
+      }),
+    };
+
+    mockGistProvider = {
+      deploy: jest.fn().mockResolvedValue({
+        success: true,
+        gistUrl: 'https://gist.github.com/abc123',
+        gistId: 'abc123',
+      }),
+    };
+
+    mockDevContainerProvider = {
+      generateDevContainerFiles: jest.fn().mockReturnValue([
+        { path: '.devcontainer/devcontainer.json', content: '{}' },
+      ]),
+    };
+
+    mockGitignoreProvider = {
+      generateGitignoreFiles: jest.fn().mockReturnValue([
+        { path: '.gitignore', content: 'node_modules/' },
+      ]),
+    };
+
+    mockCIWorkflowProvider = {
+      generateCIWorkflowFiles: jest.fn().mockReturnValue([
+        { path: '.github/workflows/test.yml', content: 'name: Test' },
+      ]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeploymentOrchestratorService,
+        {
+          provide: getRepositoryToken(Deployment),
+          useValue: mockDeploymentRepository,
+        },
+        {
+          provide: getRepositoryToken(Conversation),
+          useValue: mockConversationRepository,
+        },
+        {
+          provide: GitHubRepoProvider,
+          useValue: mockGitHubRepoProvider,
+        },
+        {
+          provide: GistProvider,
+          useValue: mockGistProvider,
+        },
+        {
+          provide: DevContainerProvider,
+          useValue: mockDevContainerProvider,
+        },
+        {
+          provide: GitignoreProvider,
+          useValue: mockGitignoreProvider,
+        },
+        {
+          provide: CIWorkflowProvider,
+          useValue: mockCIWorkflowProvider,
+        },
+      ],
+    }).compile();
+
+    service = module.get<DeploymentOrchestratorService>(DeploymentOrchestratorService);
+
+    // Mock the file reading method
+    (service as any).getGeneratedFiles = jest.fn().mockResolvedValue([
+      { path: 'src/index.ts', content: 'console.log("hello");' },
+      { path: 'package.json', content: '{"name": "test"}' },
+    ]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('deployToGitHub', () => {
+    it('should deploy to GitHub successfully', async () => {
+      const result = await service.deployToGitHub('conv-123', {});
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBe('repo');
+      expect(result.urls.repository).toBe('https://github.com/test-user/test-repo');
+      expect(result.urls.clone).toBe('https://github.com/test-user/test-repo.git');
+      expect(result.urls.codespace).toContain('codespaces');
+    });
+
+    it('should throw NotFoundException if conversation does not exist', async () => {
+      mockConversationRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.deployToGitHub('nonexistent', {})).rejects.toThrow(NotFoundException);
+    });
+
+    it('should return error if no generated files found', async () => {
+      (service as any).getGeneratedFiles.mockResolvedValue([]);
+
+      const result = await service.deployToGitHub('conv-123', {});
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('No generated files');
+    });
+
+    it('should add .gitignore files automatically', async () => {
+      await service.deployToGitHub('conv-123', {});
+
+      expect(mockGitignoreProvider.generateGitignoreFiles).toHaveBeenCalled();
+    });
+
+    it('should add CI workflow files automatically', async () => {
+      await service.deployToGitHub('conv-123', {});
+
+      expect(mockCIWorkflowProvider.generateCIWorkflowFiles).toHaveBeenCalledWith(
+        'test-mcp-server',
+      );
+    });
+
+    it('should add devcontainer files when requested', async () => {
+      await service.deployToGitHub('conv-123', { includeDevContainer: true });
+
+      expect(mockDevContainerProvider.generateDevContainerFiles).toHaveBeenCalled();
+    });
+
+    it('should not add devcontainer files by default', async () => {
+      await service.deployToGitHub('conv-123', {});
+
+      expect(mockDevContainerProvider.generateDevContainerFiles).not.toHaveBeenCalled();
+    });
+
+    it('should default to private repositories', async () => {
+      await service.deployToGitHub('conv-123', {});
+
+      expect(mockGitHubRepoProvider.deploy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.any(String),
+        true, // isPrivate should be true by default
+      );
+    });
+
+    it('should respect explicit isPrivate option', async () => {
+      await service.deployToGitHub('conv-123', { isPrivate: false });
+
+      expect(mockGitHubRepoProvider.deploy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.any(String),
+        false,
+      );
+    });
+
+    it('should use custom description when provided', async () => {
+      await service.deployToGitHub('conv-123', { description: 'Custom description' });
+
+      expect(mockGitHubRepoProvider.deploy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        'Custom description',
+        expect.any(Boolean),
+      );
+    });
+
+    it('should update deployment record on success', async () => {
+      await service.deployToGitHub('conv-123', {});
+
+      expect(mockDeploymentRepository.update).toHaveBeenCalledWith(
+        'deploy-123',
+        expect.objectContaining({
+          status: 'success',
+          repositoryUrl: 'https://github.com/test-user/test-repo',
+        }),
+      );
+    });
+
+    it('should update deployment record on failure', async () => {
+      mockGitHubRepoProvider.deploy.mockResolvedValue({
+        success: false,
+        error: 'Deployment failed',
+      });
+
+      await service.deployToGitHub('conv-123', {});
+
+      expect(mockDeploymentRepository.update).toHaveBeenCalledWith(
+        'deploy-123',
+        expect.objectContaining({
+          status: 'failed',
+          errorMessage: 'Deployment failed',
+        }),
+      );
+    });
+  });
+
+  describe('deployToGist', () => {
+    it('should deploy to Gist successfully', async () => {
+      const result = await service.deployToGist('conv-123', {});
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBe('gist');
+      expect(result.urls.gist).toBe('https://gist.github.com/abc123');
+    });
+
+    it('should throw NotFoundException if conversation does not exist', async () => {
+      mockConversationRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.deployToGist('nonexistent', {})).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getDeploymentStatus', () => {
+    it('should return deployment status for a conversation', async () => {
+      const result = await service.getDeploymentStatus('conv-123');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].conversationId).toBe('conv-123');
+      expect(mockDeploymentRepository.find).toHaveBeenCalledWith({
+        where: { conversationId: 'conv-123' },
+        order: { createdAt: 'DESC' },
+      });
+    });
+  });
+
+  describe('retryDeployment', () => {
+    it('should retry a failed repo deployment', async () => {
+      mockDeploymentRepository.findOneBy.mockResolvedValue({
+        ...mockDeployment,
+        status: 'failed',
+        deploymentType: 'repo',
+        metadata: { options: {} },
+      });
+
+      const result = await service.retryDeployment('deploy-123');
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBe('repo');
+    });
+
+    it('should retry a failed gist deployment', async () => {
+      mockDeploymentRepository.findOneBy.mockResolvedValue({
+        ...mockDeployment,
+        status: 'failed',
+        deploymentType: 'gist',
+        metadata: { options: {} },
+      });
+
+      const result = await service.retryDeployment('deploy-123');
+
+      expect(result.success).toBe(true);
+      expect(result.type).toBe('gist');
+    });
+
+    it('should throw NotFoundException if deployment does not exist', async () => {
+      mockDeploymentRepository.findOneBy.mockResolvedValue(null);
+
+      await expect(service.retryDeployment('nonexistent')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw error if deployment is not failed', async () => {
+      mockDeploymentRepository.findOneBy.mockResolvedValue({
+        ...mockDeployment,
+        status: 'success',
+      });
+
+      await expect(service.retryDeployment('deploy-123')).rejects.toThrow(
+        'Can only retry failed deployments',
+      );
+    });
+  });
+
+  describe('getLatestDeployment', () => {
+    it('should return the latest deployment for a conversation', async () => {
+      const result = await service.getLatestDeployment('conv-123');
+
+      expect(result).toEqual(mockDeployment);
+      expect(mockDeploymentRepository.findOne).toHaveBeenCalledWith({
+        where: { conversationId: 'conv-123' },
+        order: { createdAt: 'DESC' },
+      });
+    });
+
+    it('should return null if no deployments exist', async () => {
+      mockDeploymentRepository.findOne.mockResolvedValue(null);
+
+      const result = await service.getLatestDeployment('conv-123');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/backend/src/deployment/deployment.service.ts
+++ b/packages/backend/src/deployment/deployment.service.ts
@@ -9,6 +9,8 @@ import { Conversation } from '../database/entities/conversation.entity';
 import { GitHubRepoProvider } from './providers/github-repo.provider';
 import { GistProvider } from './providers/gist.provider';
 import { DevContainerProvider } from './providers/devcontainer.provider';
+import { GitignoreProvider } from './providers/gitignore.provider';
+import { CIWorkflowProvider } from './providers/ci-workflow.provider';
 import {
   DeploymentResult,
   DeploymentStatusResponse,
@@ -29,6 +31,8 @@ export class DeploymentOrchestratorService {
     private readonly gitHubRepoProvider: GitHubRepoProvider,
     private readonly gistProvider: GistProvider,
     private readonly devContainerProvider: DevContainerProvider,
+    private readonly gitignoreProvider: GitignoreProvider,
+    private readonly ciWorkflowProvider: CIWorkflowProvider,
   ) {
     this.generatedServersDir = join(process.cwd(), '../../generated-servers');
   }
@@ -68,21 +72,29 @@ export class DeploymentOrchestratorService {
         throw new Error('No generated files found for this conversation');
       }
 
+      const serverName = this.getServerName(conversation);
+
+      // Always add .gitignore
+      files.push(...this.gitignoreProvider.generateGitignoreFiles());
+
+      // Always add CI workflow for GitHub repos
+      files.push(...this.ciWorkflowProvider.generateCIWorkflowFiles(serverName));
+
       // Add devcontainer if requested
       if (options.includeDevContainer) {
         const devContainerFiles = this.devContainerProvider.generateDevContainerFiles(
-          this.getServerName(conversation),
+          serverName,
           'typescript',
         );
         files.push(...devContainerFiles);
       }
 
-      // Deploy to GitHub
+      // Deploy to GitHub (default to private repos)
       const result = await this.gitHubRepoProvider.deploy(
-        this.getServerName(conversation),
+        serverName,
         files,
         options.description || `MCP Server generated from conversation ${conversationId}`,
-        options.isPrivate ?? false,
+        options.isPrivate ?? true,
       );
 
       if (result.success) {
@@ -100,6 +112,7 @@ export class DeploymentOrchestratorService {
           type: 'repo',
           urls: {
             repository: result.repositoryUrl,
+            clone: result.cloneUrl,
             codespace: result.codespaceUrl,
           },
         };

--- a/packages/backend/src/deployment/providers/ci-workflow.provider.ts
+++ b/packages/backend/src/deployment/providers/ci-workflow.provider.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { DeploymentFile } from '../types/deployment.types';
+
+@Injectable()
+export class CIWorkflowProvider {
+  /**
+   * Generate a GitHub Actions workflow file for testing MCP servers
+   */
+  generateTestWorkflow(serverName: string): DeploymentFile {
+    const content = `name: Test MCP Server
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js \${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: \${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test --if-present
+
+      - name: Verify MCP server starts
+        run: |
+          timeout 5 node dist/index.js --help || true
+`;
+
+    return {
+      path: '.github/workflows/test.yml',
+      content,
+    };
+  }
+
+  /**
+   * Generate CI workflow files as an array for easy spreading into deployment files
+   */
+  generateCIWorkflowFiles(serverName: string): DeploymentFile[] {
+    return [this.generateTestWorkflow(serverName)];
+  }
+}

--- a/packages/backend/src/deployment/providers/github-repo.provider.spec.ts
+++ b/packages/backend/src/deployment/providers/github-repo.provider.spec.ts
@@ -1,0 +1,265 @@
+/// <reference types="jest" />
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { GitHubRepoProvider } from './github-repo.provider';
+
+describe('GitHubRepoProvider', () => {
+  let provider: GitHubRepoProvider;
+  let mockOctokit: any;
+
+  const mockConfigService = {
+    get: jest.fn().mockReturnValue('mock-github-token'),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GitHubRepoProvider,
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+
+    provider = module.get<GitHubRepoProvider>(GitHubRepoProvider);
+
+    // Mock the Octokit instance
+    mockOctokit = {
+      rest: {
+        users: {
+          getAuthenticated: jest.fn().mockResolvedValue({
+            data: { login: 'test-user' },
+          }),
+        },
+        repos: {
+          createForAuthenticatedUser: jest.fn().mockResolvedValue({
+            data: {
+              owner: { login: 'test-user' },
+              name: 'test-repo',
+              html_url: 'https://github.com/test-user/test-repo',
+              clone_url: 'https://github.com/test-user/test-repo.git',
+            },
+          }),
+          get: jest.fn().mockResolvedValue({
+            data: { default_branch: 'main' },
+          }),
+        },
+        git: {
+          getRef: jest.fn().mockResolvedValue({
+            data: { object: { sha: 'abc123' } },
+          }),
+          getCommit: jest.fn().mockResolvedValue({
+            data: { tree: { sha: 'tree123' } },
+          }),
+          createBlob: jest.fn().mockResolvedValue({
+            data: { sha: 'blob123' },
+          }),
+          createTree: jest.fn().mockResolvedValue({
+            data: { sha: 'newtree123' },
+          }),
+          createCommit: jest.fn().mockResolvedValue({
+            data: { sha: 'commit123' },
+          }),
+          updateRef: jest.fn().mockResolvedValue({}),
+        },
+      },
+    };
+
+    // Replace the octokit instance
+    (provider as any).octokit = mockOctokit;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createRepository', () => {
+    it('should create a repository successfully', async () => {
+      const result = await provider.createRepository('test-repo', 'Test description', true);
+
+      expect(result).toEqual({
+        owner: 'test-user',
+        repo: 'test-repo',
+        url: 'https://github.com/test-user/test-repo',
+        cloneUrl: 'https://github.com/test-user/test-repo.git',
+      });
+
+      expect(mockOctokit.rest.repos.createForAuthenticatedUser).toHaveBeenCalledWith({
+        name: 'test-repo',
+        description: 'Test description',
+        private: true,
+        auto_init: true,
+      });
+    });
+
+    it('should throw an error if repository creation fails', async () => {
+      mockOctokit.rest.repos.createForAuthenticatedUser.mockRejectedValue(
+        new Error('Repository already exists'),
+      );
+
+      await expect(provider.createRepository('test-repo', 'Test', false)).rejects.toThrow(
+        'Repository already exists',
+      );
+    });
+  });
+
+  describe('pushFiles', () => {
+    it('should push files to a repository successfully', async () => {
+      const files = [
+        { path: 'src/index.ts', content: 'console.log("hello");' },
+        { path: 'package.json', content: '{"name": "test"}' },
+      ];
+
+      await provider.pushFiles('test-user', 'test-repo', files, 'Initial commit');
+
+      expect(mockOctokit.rest.repos.get).toHaveBeenCalledWith({
+        owner: 'test-user',
+        repo: 'test-repo',
+      });
+
+      expect(mockOctokit.rest.git.createBlob).toHaveBeenCalledTimes(2);
+      expect(mockOctokit.rest.git.createTree).toHaveBeenCalled();
+      expect(mockOctokit.rest.git.createCommit).toHaveBeenCalled();
+      expect(mockOctokit.rest.git.updateRef).toHaveBeenCalled();
+    });
+  });
+
+  describe('repositoryExists', () => {
+    it('should return true if repository exists', async () => {
+      const result = await provider.repositoryExists('test-user', 'test-repo');
+      expect(result).toBe(true);
+    });
+
+    it('should return false if repository does not exist', async () => {
+      mockOctokit.rest.repos.get.mockRejectedValue(new Error('Not found'));
+
+      const result = await provider.repositoryExists('test-user', 'nonexistent-repo');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('deploy', () => {
+    it('should deploy files to a new repository successfully', async () => {
+      // Mock repositoryExists to return false (no conflict)
+      jest.spyOn(provider, 'repositoryExists').mockResolvedValue(false);
+
+      const files = [{ path: 'src/index.ts', content: 'console.log("hello");' }];
+
+      const result = await provider.deploy('test-server', files, 'Test MCP server', true);
+
+      expect(result.success).toBe(true);
+      expect(result.repositoryUrl).toBe('https://github.com/test-user/test-repo');
+      expect(result.cloneUrl).toBe('https://github.com/test-user/test-repo.git');
+      expect(result.codespaceUrl).toContain('codespaces/new');
+    });
+
+    it('should handle naming conflicts by appending timestamp', async () => {
+      // Mock repositoryExists to return true first, then false
+      jest
+        .spyOn(provider, 'repositoryExists')
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+
+      const files = [{ path: 'src/index.ts', content: 'console.log("hello");' }];
+
+      const result = await provider.deploy('test-server', files, 'Test MCP server', false);
+
+      expect(result.success).toBe(true);
+      expect(provider.repositoryExists).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fail after max naming conflict attempts', async () => {
+      // Mock repositoryExists to always return true
+      jest.spyOn(provider, 'repositoryExists').mockResolvedValue(true);
+
+      const files = [{ path: 'src/index.ts', content: 'console.log("hello");' }];
+
+      const result = await provider.deploy('test-server', files, 'Test MCP server', false);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to find unique repository name');
+    });
+
+    it('should return error result on deployment failure', async () => {
+      jest.spyOn(provider, 'repositoryExists').mockResolvedValue(false);
+      mockOctokit.rest.repos.createForAuthenticatedUser.mockRejectedValue(
+        new Error('API error'),
+      );
+
+      const files = [{ path: 'src/index.ts', content: 'console.log("hello");' }];
+
+      const result = await provider.deploy('test-server', files, 'Test MCP server', false);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API error');
+    });
+  });
+
+  describe('rate limit handling', () => {
+    it('should retry on rate limit error (429)', async () => {
+      const rateLimitError = new Error('Rate limit exceeded');
+      (rateLimitError as any).status = 429;
+
+      mockOctokit.rest.repos.createForAuthenticatedUser
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce({
+          data: {
+            owner: { login: 'test-user' },
+            name: 'test-repo',
+            html_url: 'https://github.com/test-user/test-repo',
+            clone_url: 'https://github.com/test-user/test-repo.git',
+          },
+        });
+
+      const result = await provider.createRepository('test-repo', 'Test', false);
+
+      expect(result.owner).toBe('test-user');
+      expect(mockOctokit.rest.repos.createForAuthenticatedUser).toHaveBeenCalledTimes(2);
+    }, 10000);
+
+    it('should retry on rate limit error (403)', async () => {
+      const rateLimitError = new Error('Secondary rate limit');
+      (rateLimitError as any).status = 403;
+
+      mockOctokit.rest.repos.createForAuthenticatedUser
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce({
+          data: {
+            owner: { login: 'test-user' },
+            name: 'test-repo',
+            html_url: 'https://github.com/test-user/test-repo',
+            clone_url: 'https://github.com/test-user/test-repo.git',
+          },
+        });
+
+      const result = await provider.createRepository('test-repo', 'Test', false);
+
+      expect(result.owner).toBe('test-user');
+    }, 10000);
+
+    it('should throw non-rate-limit errors immediately', async () => {
+      const error = new Error('Not found');
+      (error as any).status = 404;
+
+      mockOctokit.rest.repos.createForAuthenticatedUser.mockRejectedValue(error);
+
+      await expect(provider.createRepository('test-repo', 'Test', false)).rejects.toThrow(
+        'Not found',
+      );
+
+      expect(mockOctokit.rest.repos.createForAuthenticatedUser).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sanitizeRepoName', () => {
+    it('should sanitize repository names correctly', () => {
+      const sanitize = (provider as any).sanitizeRepoName.bind(provider);
+
+      expect(sanitize('My Cool Server')).toBe('my-cool-server');
+      expect(sanitize('server@123!!')).toBe('server-123');
+      expect(sanitize('--test--')).toBe('test');
+      expect(sanitize('a'.repeat(150))).toHaveLength(100);
+    });
+  });
+});

--- a/packages/backend/src/deployment/providers/gitignore.provider.ts
+++ b/packages/backend/src/deployment/providers/gitignore.provider.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { DeploymentFile } from '../types/deployment.types';
+
+@Injectable()
+export class GitignoreProvider {
+  /**
+   * Generate a .gitignore file for Node.js/TypeScript MCP servers
+   */
+  generateGitignoreFile(): DeploymentFile {
+    const content = `# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Test coverage
+coverage/
+
+# TypeScript cache
+*.tsbuildinfo
+`;
+
+    return {
+      path: '.gitignore',
+      content,
+    };
+  }
+
+  /**
+   * Generate .gitignore files as an array for easy spreading into deployment files
+   */
+  generateGitignoreFiles(): DeploymentFile[] {
+    return [this.generateGitignoreFile()];
+  }
+}

--- a/packages/backend/src/deployment/types/deployment.types.ts
+++ b/packages/backend/src/deployment/types/deployment.types.ts
@@ -16,6 +16,7 @@ export interface DeploymentUrls {
   repository?: string;
   gist?: string;
   codespace?: string;
+  clone?: string;
 }
 
 export interface DeploymentOptions {
@@ -46,6 +47,7 @@ export interface DeploymentStatusResponse {
 export interface GitHubRepoResult {
   success: boolean;
   repositoryUrl?: string;
+  cloneUrl?: string;
   codespaceUrl?: string;
   error?: string;
 }

--- a/packages/backend/test/deployment.e2e-spec.ts
+++ b/packages/backend/test/deployment.e2e-spec.ts
@@ -1,0 +1,278 @@
+/// <reference types="jest" />
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Octokit } from '@octokit/rest';
+import { GitHubRepoProvider } from '../src/deployment/providers/github-repo.provider';
+import { DeploymentFile } from '../src/deployment/types/deployment.types';
+
+/**
+ * Integration tests for GitHub deployment functionality.
+ *
+ * These tests create real GitHub repositories and should be run with care.
+ * They require a valid GITHUB_TOKEN with repo scope.
+ *
+ * Run with: npm run test:e2e -- --testPathPattern=deployment
+ *
+ * IMPORTANT: These tests create real repositories that are cleaned up after each test.
+ * If a test fails, you may need to manually delete test repositories.
+ */
+describe('Deployment Integration Tests (e2e)', () => {
+  let app: INestApplication;
+  let gitHubRepoProvider: GitHubRepoProvider;
+  let octokit: Octokit;
+  let owner: string;
+  const createdRepos: string[] = [];
+
+  const TEST_REPO_PREFIX = 'mcp-test-e2e-';
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+        }),
+      ],
+      providers: [GitHubRepoProvider],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    gitHubRepoProvider = moduleFixture.get<GitHubRepoProvider>(GitHubRepoProvider);
+
+    const configService = moduleFixture.get<ConfigService>(ConfigService);
+    const githubToken = configService.get<string>('GITHUB_TOKEN');
+
+    if (!githubToken) {
+      throw new Error('GITHUB_TOKEN is required for integration tests');
+    }
+
+    octokit = new Octokit({ auth: githubToken });
+
+    // Get authenticated user
+    const { data: user } = await octokit.rest.users.getAuthenticated();
+    owner = user.login;
+  });
+
+  afterAll(async () => {
+    // Clean up all created repositories
+    for (const repo of createdRepos) {
+      try {
+        await octokit.rest.repos.delete({ owner, repo });
+        console.log(`Cleaned up test repository: ${owner}/${repo}`);
+      } catch (error) {
+        console.warn(`Failed to clean up repository ${owner}/${repo}: ${error.message}`);
+      }
+    }
+
+    await app.close();
+  });
+
+  const generateTestRepoName = (): string => {
+    return `${TEST_REPO_PREFIX}${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  };
+
+  const trackCreatedRepo = (repoName: string): void => {
+    createdRepos.push(repoName);
+  };
+
+  describe('GitHubRepoProvider Integration', () => {
+    it('should create a real GitHub repository', async () => {
+      const repoName = generateTestRepoName();
+      const description = 'Test repository for MCP Everything e2e tests';
+
+      const result = await gitHubRepoProvider.createRepository(repoName, description, true);
+      trackCreatedRepo(result.repo);
+
+      expect(result.owner).toBe(owner);
+      expect(result.repo).toBe(repoName);
+      expect(result.url).toContain(`github.com/${owner}/${repoName}`);
+      expect(result.cloneUrl).toContain('.git');
+
+      // Verify repository exists
+      const { data: repoData } = await octokit.rest.repos.get({
+        owner,
+        repo: repoName,
+      });
+
+      expect(repoData.name).toBe(repoName);
+      expect(repoData.private).toBe(true);
+      expect(repoData.description).toBe(description);
+    }, 30000);
+
+    it('should push files to a repository', async () => {
+      const repoName = generateTestRepoName();
+
+      // First create the repository
+      const createResult = await gitHubRepoProvider.createRepository(
+        repoName,
+        'Test repo for file push',
+        true,
+      );
+      trackCreatedRepo(createResult.repo);
+
+      // Wait for repo to be ready
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // Push test files
+      const files: DeploymentFile[] = [
+        {
+          path: 'src/index.ts',
+          content: `
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+const server = new Server({
+  name: 'test-mcp-server',
+  version: '1.0.0',
+});
+
+export default server;
+`.trim(),
+        },
+        {
+          path: 'package.json',
+          content: JSON.stringify(
+            {
+              name: 'test-mcp-server',
+              version: '1.0.0',
+              type: 'module',
+              main: 'dist/index.js',
+              scripts: {
+                build: 'tsc',
+                test: 'echo "No tests"',
+              },
+              dependencies: {
+                '@modelcontextprotocol/sdk': '^1.0.0',
+              },
+              devDependencies: {
+                typescript: '^5.0.0',
+              },
+            },
+            null,
+            2,
+          ),
+        },
+        {
+          path: 'tsconfig.json',
+          content: JSON.stringify(
+            {
+              compilerOptions: {
+                target: 'ES2022',
+                module: 'NodeNext',
+                moduleResolution: 'NodeNext',
+                outDir: './dist',
+                strict: true,
+              },
+              include: ['src/**/*'],
+            },
+            null,
+            2,
+          ),
+        },
+      ];
+
+      await gitHubRepoProvider.pushFiles(owner, repoName, files, 'Add MCP server code');
+
+      // Verify files exist in repository
+      const { data: srcIndex } = await octokit.rest.repos.getContent({
+        owner,
+        repo: repoName,
+        path: 'src/index.ts',
+      });
+
+      expect(srcIndex).toBeDefined();
+      expect((srcIndex as any).name).toBe('index.ts');
+    }, 60000);
+
+    it('should deploy a complete MCP server', async () => {
+      const serverName = generateTestRepoName();
+
+      const files: DeploymentFile[] = [
+        { path: 'src/index.ts', content: 'console.log("Hello MCP");' },
+        { path: 'package.json', content: '{"name": "test", "version": "1.0.0"}' },
+        { path: '.gitignore', content: 'node_modules/\ndist/\n.env\n' },
+        {
+          path: '.github/workflows/test.yml',
+          content: `name: Test\non: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n`,
+        },
+      ];
+
+      const result = await gitHubRepoProvider.deploy(
+        serverName,
+        files,
+        'Complete MCP server deployment test',
+        true,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.repositoryUrl).toContain('github.com');
+      expect(result.cloneUrl).toContain('.git');
+      expect(result.codespaceUrl).toContain('codespaces');
+
+      // Track for cleanup
+      const repoName = result.repositoryUrl!.split('/').pop()!;
+      trackCreatedRepo(repoName);
+
+      // Verify all files exist
+      const { data: files1 } = await octokit.rest.repos.getContent({
+        owner,
+        repo: repoName,
+        path: '',
+      });
+
+      const fileNames = Array.isArray(files1) ? files1.map((f) => f.name) : [];
+      expect(fileNames).toContain('src');
+      expect(fileNames).toContain('package.json');
+      expect(fileNames).toContain('.gitignore');
+      expect(fileNames).toContain('.github');
+    }, 60000);
+
+    it('should handle naming conflicts', async () => {
+      const baseName = generateTestRepoName();
+
+      // Create first repository
+      const result1 = await gitHubRepoProvider.createRepository(baseName, 'First repo', true);
+      trackCreatedRepo(result1.repo);
+
+      // Wait a bit
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // Try to deploy with the same name - should get a different name due to conflict handling
+      const files: DeploymentFile[] = [{ path: 'README.md', content: '# Test' }];
+
+      const result2 = await gitHubRepoProvider.deploy(
+        baseName,
+        files,
+        'Should get renamed due to conflict',
+        true,
+      );
+
+      expect(result2.success).toBe(true);
+
+      // The new repo should have a different name (with timestamp suffix)
+      const newRepoName = result2.repositoryUrl!.split('/').pop()!;
+      trackCreatedRepo(newRepoName);
+
+      expect(newRepoName).not.toBe(baseName);
+      expect(newRepoName).toContain(baseName);
+    }, 60000);
+  });
+
+  describe('Error Handling', () => {
+    it('should handle repository creation errors gracefully', async () => {
+      // Try to create a repo with invalid name
+      const result = await gitHubRepoProvider.deploy(
+        '.',
+        [{ path: 'README.md', content: '# Test' }],
+        'Test',
+        true,
+      );
+
+      // The sanitizer should handle this, resulting in an empty or minimal name
+      // which should either fail or be handled gracefully
+      // This test verifies error handling doesn't crash
+      expect(typeof result.success).toBe('boolean');
+    }, 30000);
+  });
+});

--- a/packages/backend/test/jest-e2e.json
+++ b/packages/backend/test/jest-e2e.json
@@ -1,0 +1,12 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
+  }
+}


### PR DESCRIPTION
## Summary
- Completes GitHub repository creation functionality for Issue #3
- Adds naming conflict handling (appends timestamp suffix when repo exists)
- Adds rate limit handling with exponential backoff retry
- Adds cloneUrl to deployment response
- Defaults repositories to private instead of public
- Auto-generates .gitignore and GitHub Actions CI workflow for all deployments

## Changes
- **New providers**: GitignoreProvider, CIWorkflowProvider
- **Enhanced GitHubRepoProvider**: Conflict handling, rate limiting, cloneUrl
- **Updated DeploymentOrchestratorService**: Wires up new providers, defaults to private

## Test plan
- [x] 34 unit tests passing for GitHubRepoProvider and DeploymentOrchestratorService
- [x] E2E integration test suite created for real GitHub API testing
- [ ] Manual testing of deployment flow

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)