### PR TITLE
feat(deployment): Complete DeploymentService with CRUD, pagination, and enterprise stub

### DIFF
--- a/packages/backend/src/deployment/dto/deploy-request.dto.ts
+++ b/packages/backend/src/deployment/dto/deploy-request.dto.ts
@@ -1,9 +1,12 @@
 import {
   IsString,
   IsUUID,
-  IsEnum,
   IsOptional,
   IsBoolean,
+  IsNumber,
+  IsIn,
+  Min,
+  Max,
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -65,11 +68,12 @@ export class RetryDeploymentDto {
 export class DeploymentResponseDto {
   success: boolean;
   deploymentId?: string;
-  type?: 'gist' | 'repo' | 'none';
+  type?: 'gist' | 'repo' | 'enterprise' | 'none';
   urls?: {
     repository?: string;
     gist?: string;
     codespace?: string;
+    enterprise?: string;
   };
   error?: string;
 }
@@ -80,14 +84,91 @@ export class DeploymentResponseDto {
 export class DeploymentStatusDto {
   deploymentId: string;
   conversationId: string;
-  type: 'gist' | 'repo' | 'none';
+  type: 'gist' | 'repo' | 'enterprise' | 'none';
   status: 'pending' | 'success' | 'failed';
   urls: {
     repository?: string;
     gist?: string;
+    gistRaw?: string;
     codespace?: string;
+    enterprise?: string;
   };
   errorMessage?: string;
   createdAt: Date;
   deployedAt?: Date;
+}
+
+/**
+ * DTO for updating a Gist deployment
+ */
+export class UpdateGistDto {
+  @IsOptional()
+  @IsString()
+  description?: string;
+}
+
+/**
+ * Query DTO for listing deployments with filtering and pagination
+ */
+export class ListDeploymentsQueryDto {
+  @IsOptional()
+  @IsIn(['gist', 'repo', 'enterprise'])
+  type?: string;
+
+  @IsOptional()
+  @IsIn(['pending', 'success', 'failed'])
+  status?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  offset?: number;
+}
+
+/**
+ * Response DTO for paginated deployments list
+ */
+export class PaginatedDeploymentsDto {
+  deployments: DeploymentStatusDto[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Enterprise deployment options (stub for future implementation)
+ */
+export class EnterpriseOptionsDto {
+  @IsOptional()
+  @IsString()
+  customDomain?: string;
+
+  @IsOptional()
+  @IsString()
+  region?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  enableCdn?: boolean;
+}
+
+/**
+ * DTO for deploying to enterprise (stub for future implementation)
+ */
+export class DeployToEnterpriseDto {
+  @IsUUID()
+  conversationId: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => EnterpriseOptionsDto)
+  options?: EnterpriseOptionsDto;
 }

--- a/packages/backend/src/deployment/types/deployment.types.ts
+++ b/packages/backend/src/deployment/types/deployment.types.ts
@@ -6,7 +6,7 @@
 
 import { CollectedEnvVar } from '../../types/env-variable.types';
 
-export type DeploymentType = 'gist' | 'repo' | 'none';
+export type DeploymentType = 'gist' | 'repo' | 'enterprise' | 'none';
 export type DeploymentStatus = 'pending' | 'success' | 'failed';
 
 export interface DeploymentFile {
@@ -20,6 +20,7 @@ export interface DeploymentUrls {
   gistRaw?: string;
   codespace?: string;
   clone?: string;
+  enterprise?: string;
 }
 
 export interface DeploymentOptions {
@@ -77,4 +78,41 @@ export interface DevContainerConfig {
   };
   postCreateCommand: string;
   remoteUser: string;
+}
+
+/**
+ * Enterprise deployment options (stub for future implementation)
+ */
+export interface EnterpriseDeploymentOptions {
+  customDomain?: string;
+  region?: string;
+  enableCdn?: boolean;
+}
+
+/**
+ * Filters for listing deployments
+ */
+export interface DeploymentFilters {
+  type?: DeploymentType;
+  status?: DeploymentStatus;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * Paginated deployment list result
+ */
+export interface PaginatedDeployments {
+  deployments: DeploymentStatusResponse[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Delete deployment result
+ */
+export interface DeleteDeploymentResult {
+  success: boolean;
+  error?: string;
 }


### PR DESCRIPTION
## Summary
- Add CRUD completeness for deployments (update/delete gists and repos)
- Add deployment listing endpoint with filtering and pagination
- Add enterprise deployment stub (returns 501 Not Implemented)
- Add comprehensive unit tests for all new functionality

## New Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| `GET` | `/api/deploy` | List all deployments (with type/status filtering, pagination) |
| `GET` | `/api/deploy/id/:deploymentId` | Get single deployment by ID |
| `PATCH` | `/api/deploy/gist/:deploymentId` | Update gist deployment |
| `DELETE` | `/api/deploy/gist/:deploymentId` | Delete gist deployment |
| `DELETE` | `/api/deploy/repo/:deploymentId` | Delete repository deployment |
| `POST` | `/api/deploy/enterprise` | Enterprise deployment (stub - returns 501) |

## Changes
- **deployment.controller.ts**: Add 6 new endpoints
- **deployment.service.ts**: Add `getDeploymentById`, `listDeployments`, `updateGistDeployment`, `deleteGistDeployment`, `deleteRepoDeployment`, `deployToEnterprise`
- **github-repo.provider.ts**: Add `deleteRepository()` and `parseRepoUrl()` methods
- **deploy-request.dto.ts**: Add `UpdateGistDto`, `ListDeploymentsQueryDto`, `PaginatedDeploymentsDto`, `EnterpriseOptionsDto`, `DeployToEnterpriseDto`
- **deployment.types.ts**: Add 'enterprise' to `DeploymentType`, add `EnterpriseDeploymentOptions`, `DeploymentFilters`, `PaginatedDeployments`, `DeleteDeploymentResult`

## Test plan
- [x] TypeScript compiles without errors
- [x] 63 unit tests pass for deployment module
- [ ] Manual testing of new endpoints

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)