### PR TITLE
feat(deployment): Add comprehensive error handling, retry logic, and rollback

### DIFF
--- a/packages/backend/src/deployment/deployment.module.ts
+++ b/packages/backend/src/deployment/deployment.module.ts
@@ -14,6 +14,9 @@ import { DevContainerProvider } from './providers/devcontainer.provider';
 import { GitignoreProvider } from './providers/gitignore.provider';
 import { CIWorkflowProvider } from './providers/ci-workflow.provider';
 
+import { DeploymentRetryService } from './services/retry.service';
+import { DeploymentRollbackService } from './services/rollback.service';
+
 @Module({
   imports: [
     TypeOrmModule.forFeature([Deployment, Conversation]),
@@ -31,7 +34,9 @@ import { CIWorkflowProvider } from './providers/ci-workflow.provider';
     DevContainerProvider,
     GitignoreProvider,
     CIWorkflowProvider,
+    DeploymentRetryService,
+    DeploymentRollbackService,
   ],
-  exports: [DeploymentOrchestratorService],
+  exports: [DeploymentOrchestratorService, DeploymentRetryService],
 })
 export class DeploymentModule {}

--- a/packages/backend/src/deployment/dto/deploy-request.dto.ts
+++ b/packages/backend/src/deployment/dto/deploy-request.dto.ts
@@ -66,6 +66,15 @@ export class DeployToGistDto {
 export class RetryDeploymentDto {
   @IsUUID()
   deploymentId: string;
+
+  @IsOptional()
+  @IsBoolean()
+  forceRetry?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  newServerName?: string;
 }
 
 /**
@@ -78,10 +87,21 @@ export class DeploymentResponseDto {
   urls?: {
     repository?: string;
     gist?: string;
+    gistRaw?: string;
     codespace?: string;
     enterprise?: string;
   };
   error?: string;
+  /** Structured error code for programmatic handling */
+  errorCode?: string;
+  /** Recommended retry strategy: 'immediate' | 'exponential_backoff' | 'manual' | 'none' */
+  retryStrategy?: string;
+  /** Milliseconds to wait before retrying (for rate limits) */
+  retryAfterMs?: number;
+  /** Alternative server names when naming conflict occurs */
+  suggestedNames?: string[];
+  /** Whether this deployment can be retried */
+  canRetry?: boolean;
 }
 
 /**
@@ -100,6 +120,12 @@ export class DeploymentStatusDto {
     enterprise?: string;
   };
   errorMessage?: string;
+  /** Structured error code */
+  errorCode?: string;
+  /** Number of retry attempts made */
+  retryCount?: number;
+  /** Whether this deployment can be retried */
+  canRetry?: boolean;
   createdAt: Date;
   deployedAt?: Date;
 }

--- a/packages/backend/src/deployment/services/retry.service.ts
+++ b/packages/backend/src/deployment/services/retry.service.ts
@@ -1,0 +1,243 @@
+import { Injectable, Logger } from '@nestjs/common';
+import {
+  DeploymentErrorCode,
+  RetryStrategy,
+  ERROR_RETRY_CONFIG,
+  RetryAttempt,
+  DeploymentError,
+  ERROR_USER_MESSAGES,
+} from '../types/deployment-errors.types';
+
+/**
+ * Result of a retry operation
+ */
+export interface RetryResult<T> {
+  result?: T;
+  error?: DeploymentError;
+  attempts: RetryAttempt[];
+}
+
+/**
+ * Context for a retry operation
+ */
+export interface RetryContext {
+  operation: string;
+  maxRetries?: number;
+}
+
+@Injectable()
+export class DeploymentRetryService {
+  private readonly logger = new Logger(DeploymentRetryService.name);
+
+  /**
+   * Parse a GitHub API error and return a structured deployment error
+   */
+  parseGitHubError(error: unknown): DeploymentError {
+    const err = error as {
+      status?: number;
+      response?: { status?: number; headers?: Record<string, string> };
+      headers?: Record<string, string>;
+      message?: string;
+    };
+
+    const status = err.status || err.response?.status;
+    const message = err.message || 'Unknown error';
+
+    let code: DeploymentErrorCode;
+
+    switch (status) {
+      case 401:
+        code = DeploymentErrorCode.AUTHENTICATION_FAILED;
+        break;
+      case 403:
+        if (message.includes('rate limit') || message.includes('secondary')) {
+          code = message.includes('secondary')
+            ? DeploymentErrorCode.SECONDARY_RATE_LIMIT
+            : DeploymentErrorCode.RATE_LIMIT_EXCEEDED;
+        } else {
+          code = DeploymentErrorCode.INSUFFICIENT_PERMISSIONS;
+        }
+        break;
+      case 404:
+        code = message.toLowerCase().includes('gist')
+          ? DeploymentErrorCode.GIST_NOT_FOUND
+          : DeploymentErrorCode.REPOSITORY_NOT_FOUND;
+        break;
+      case 422:
+        if (message.includes('name already exists')) {
+          code = DeploymentErrorCode.REPOSITORY_NAME_CONFLICT;
+        } else {
+          code = DeploymentErrorCode.INVALID_SERVER_NAME;
+        }
+        break;
+      case 429:
+        code = DeploymentErrorCode.RATE_LIMIT_EXCEEDED;
+        break;
+      case 502:
+      case 503:
+      case 504:
+        code = DeploymentErrorCode.SERVICE_UNAVAILABLE;
+        break;
+      case 0:
+      case undefined:
+        if (message.includes('timeout') || message.includes('ETIMEDOUT')) {
+          code = DeploymentErrorCode.NETWORK_TIMEOUT;
+        } else if (message.includes('ECONNRESET')) {
+          code = DeploymentErrorCode.CONNECTION_RESET;
+        } else {
+          code = DeploymentErrorCode.UNKNOWN_ERROR;
+        }
+        break;
+      default:
+        code = DeploymentErrorCode.UNKNOWN_ERROR;
+    }
+
+    const config = ERROR_RETRY_CONFIG[code];
+    const retryAfterMs = this.extractRetryAfter(err);
+
+    return {
+      code,
+      message,
+      userMessage: ERROR_USER_MESSAGES[code],
+      retryStrategy: config.strategy,
+      retryAfterMs: retryAfterMs || config.baseDelayMs,
+    };
+  }
+
+  /**
+   * Extract retry-after timing from GitHub response headers
+   */
+  private extractRetryAfter(error: {
+    response?: { headers?: Record<string, string> };
+    headers?: Record<string, string>;
+  }): number | undefined {
+    const resetHeader =
+      error.response?.headers?.['x-ratelimit-reset'] ||
+      error.headers?.['x-ratelimit-reset'];
+
+    if (resetHeader) {
+      const resetTime = parseInt(resetHeader, 10) * 1000;
+      const waitTime = resetTime - Date.now();
+      if (waitTime > 0 && waitTime < 60000) {
+        return waitTime + 1000; // Add 1s buffer
+      }
+    }
+
+    const retryAfter = error.response?.headers?.['retry-after'];
+    if (retryAfter) {
+      return parseInt(retryAfter, 10) * 1000;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Execute a function with retry logic based on error type
+   */
+  async withRetry<T>(
+    fn: () => Promise<T>,
+    context: RetryContext,
+    onRetry?: (attempt: RetryAttempt) => Promise<void>,
+  ): Promise<RetryResult<T>> {
+    const attempts: RetryAttempt[] = [];
+    let lastError: DeploymentError | undefined;
+
+    const maxRetries = context.maxRetries ?? 3;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const result = await fn();
+        return { result, attempts };
+      } catch (error) {
+        lastError = this.parseGitHubError(error);
+        const config = ERROR_RETRY_CONFIG[lastError.code];
+
+        const retryAttempt: RetryAttempt = {
+          attemptNumber: attempt + 1,
+          timestamp: new Date().toISOString(),
+          errorCode: lastError.code,
+          errorMessage: lastError.message,
+        };
+        attempts.push(retryAttempt);
+
+        // Log the error
+        this.logger.warn(
+          `${context.operation} failed (attempt ${attempt + 1}): ${lastError.code} - ${lastError.message}`,
+        );
+
+        // Check if we should retry
+        if (
+          config.strategy === RetryStrategy.NONE ||
+          config.strategy === RetryStrategy.MANUAL
+        ) {
+          break;
+        }
+
+        if (attempt >= maxRetries) {
+          break;
+        }
+
+        // Calculate delay
+        const delayMs =
+          config.strategy === RetryStrategy.EXPONENTIAL_BACKOFF
+            ? Math.pow(2, attempt) * config.baseDelayMs
+            : config.baseDelayMs;
+
+        const actualDelay = lastError.retryAfterMs
+          ? Math.max(delayMs, lastError.retryAfterMs)
+          : delayMs;
+
+        retryAttempt.waitedMs = actualDelay;
+
+        this.logger.log(
+          `Waiting ${actualDelay}ms before retry ${attempt + 2}`,
+        );
+
+        if (onRetry) {
+          await onRetry(retryAttempt);
+        }
+
+        await this.delay(actualDelay);
+      }
+    }
+
+    return { error: lastError, attempts };
+  }
+
+  /**
+   * Generate alternative server names for naming conflicts
+   */
+  generateAlternativeNames(baseName: string, count: number = 3): string[] {
+    const suggestions: string[] = [];
+    const timestamp = Date.now().toString().slice(-6);
+
+    suggestions.push(`${baseName}-${timestamp}`);
+    suggestions.push(`${baseName}-v2`);
+    suggestions.push(`${baseName}-${Math.random().toString(36).slice(2, 6)}`);
+
+    return suggestions.slice(0, count);
+  }
+
+  /**
+   * Check if an error code allows retry
+   */
+  canRetry(errorCode: DeploymentErrorCode, currentRetries: number = 0): boolean {
+    const config = ERROR_RETRY_CONFIG[errorCode];
+    return (
+      config.strategy !== RetryStrategy.NONE &&
+      config.strategy !== RetryStrategy.MANUAL &&
+      currentRetries < config.maxRetries
+    );
+  }
+
+  /**
+   * Get retry strategy for an error code
+   */
+  getRetryStrategy(errorCode: DeploymentErrorCode): RetryStrategy {
+    return ERROR_RETRY_CONFIG[errorCode].strategy;
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/backend/src/deployment/services/rollback.service.ts
+++ b/packages/backend/src/deployment/services/rollback.service.ts
@@ -1,0 +1,173 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Deployment } from '../../database/entities/deployment.entity';
+import { GitHubRepoProvider } from '../providers/github-repo.provider';
+import { GistProvider } from '../providers/gist.provider';
+
+/**
+ * Result of a rollback operation
+ */
+export interface RollbackResult {
+  success: boolean;
+  resourcesDeleted: string[];
+  errors: string[];
+}
+
+@Injectable()
+export class DeploymentRollbackService {
+  private readonly logger = new Logger(DeploymentRollbackService.name);
+
+  constructor(
+    @InjectRepository(Deployment)
+    private readonly deploymentRepository: Repository<Deployment>,
+    private readonly gitHubRepoProvider: GitHubRepoProvider,
+    private readonly gistProvider: GistProvider,
+  ) {}
+
+  /**
+   * Rollback a failed deployment by cleaning up created resources
+   */
+  async rollback(deploymentId: string, reason: string): Promise<RollbackResult> {
+    const result: RollbackResult = {
+      success: true,
+      resourcesDeleted: [],
+      errors: [],
+    };
+
+    const deployment = await this.deploymentRepository.findOneBy({
+      id: deploymentId,
+    });
+    if (!deployment) {
+      result.success = false;
+      result.errors.push('Deployment not found');
+      return result;
+    }
+
+    this.logger.log(
+      `Starting rollback for deployment ${deploymentId}: ${reason}`,
+    );
+
+    try {
+      if (deployment.deploymentType === 'repo' && deployment.repositoryUrl) {
+        await this.rollbackRepository(deployment, result);
+      } else if (deployment.deploymentType === 'gist') {
+        await this.rollbackGist(deployment, result);
+      }
+
+      // Update deployment metadata with rollback info
+      const updatedMetadata = {
+        ...(deployment.metadata || {}),
+        rollbackPerformed: true,
+        rollbackReason: reason,
+        rollbackTimestamp: new Date().toISOString(),
+      };
+
+      await this.deploymentRepository.update(deploymentId, {
+        metadata: updatedMetadata as Record<string, any>,
+      });
+    } catch (error) {
+      result.success = false;
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      result.errors.push(`Rollback error: ${errorMessage}`);
+      this.logger.error(`Rollback failed for ${deploymentId}: ${errorMessage}`);
+    }
+
+    return result;
+  }
+
+  /**
+   * Rollback a repository deployment by deleting the repository
+   */
+  private async rollbackRepository(
+    deployment: Deployment,
+    result: RollbackResult,
+  ): Promise<void> {
+    const parsed = this.gitHubRepoProvider.parseRepoUrl(
+      deployment.repositoryUrl!,
+    );
+    if (!parsed) {
+      result.errors.push(
+        `Could not parse repository URL: ${deployment.repositoryUrl}`,
+      );
+      return;
+    }
+
+    try {
+      const deleted = await this.gitHubRepoProvider.deleteRepository(
+        parsed.owner,
+        parsed.repo,
+      );
+      if (deleted) {
+        result.resourcesDeleted.push(
+          `Repository: ${parsed.owner}/${parsed.repo}`,
+        );
+        this.logger.log(
+          `Rolled back repository: ${parsed.owner}/${parsed.repo}`,
+        );
+      } else {
+        result.errors.push(
+          `Failed to delete repository: ${parsed.owner}/${parsed.repo}`,
+        );
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      result.errors.push(`Repository deletion error: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Rollback a gist deployment by deleting the gist
+   */
+  private async rollbackGist(
+    deployment: Deployment,
+    result: RollbackResult,
+  ): Promise<void> {
+    const gistId = deployment.metadata?.gistId as string | undefined;
+    if (!gistId) {
+      this.logger.debug('No gist ID found, nothing to rollback');
+      return;
+    }
+
+    try {
+      const deleted = await this.gistProvider.deleteGist(gistId);
+      if (deleted) {
+        result.resourcesDeleted.push(`Gist: ${gistId}`);
+        this.logger.log(`Rolled back gist: ${gistId}`);
+      } else {
+        result.errors.push(`Failed to delete gist: ${gistId}`);
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      result.errors.push(`Gist deletion error: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Check if a deployment can be rolled back
+   */
+  canRollback(deployment: Deployment): boolean {
+    if (deployment.status !== 'failed') {
+      return false;
+    }
+
+    // Check if rollback was already performed
+    if (deployment.metadata?.rollbackPerformed) {
+      return false;
+    }
+
+    // Check if there are resources to roll back
+    if (deployment.deploymentType === 'repo' && deployment.repositoryUrl) {
+      return true;
+    }
+
+    if (deployment.deploymentType === 'gist' && deployment.metadata?.gistId) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/packages/backend/src/deployment/types/deployment-errors.types.ts
+++ b/packages/backend/src/deployment/types/deployment-errors.types.ts
@@ -1,0 +1,243 @@
+/**
+ * Deployment Error Types
+ *
+ * Structured error codes, retry strategies, and user-friendly messages
+ * for comprehensive deployment error handling.
+ */
+
+/**
+ * Deployment Error Codes
+ * Categorized by their retry strategy
+ */
+export enum DeploymentErrorCode {
+  // === IMMEDIATE RETRY (Network/Transient) ===
+  NETWORK_TIMEOUT = 'NETWORK_TIMEOUT',
+  CONNECTION_RESET = 'CONNECTION_RESET',
+  SERVICE_UNAVAILABLE = 'SERVICE_UNAVAILABLE',
+
+  // === EXPONENTIAL BACKOFF (Rate Limits) ===
+  RATE_LIMIT_EXCEEDED = 'RATE_LIMIT_EXCEEDED',
+  SECONDARY_RATE_LIMIT = 'SECONDARY_RATE_LIMIT',
+
+  // === MANUAL RETRY (User Intervention Required) ===
+  INVALID_CODE = 'INVALID_CODE',
+  COMPILATION_ERROR = 'COMPILATION_ERROR',
+  MISSING_DEPENDENCIES = 'MISSING_DEPENDENCIES',
+  INVALID_SERVER_NAME = 'INVALID_SERVER_NAME',
+
+  // === NO RETRY (Fatal) ===
+  AUTHENTICATION_FAILED = 'AUTHENTICATION_FAILED',
+  INSUFFICIENT_PERMISSIONS = 'INSUFFICIENT_PERMISSIONS',
+  REPOSITORY_NAME_CONFLICT = 'REPOSITORY_NAME_CONFLICT',
+  GIST_NOT_FOUND = 'GIST_NOT_FOUND',
+  REPOSITORY_NOT_FOUND = 'REPOSITORY_NOT_FOUND',
+
+  // === INTERNAL ===
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+  NO_FILES_TO_DEPLOY = 'NO_FILES_TO_DEPLOY',
+  CONVERSATION_NOT_FOUND = 'CONVERSATION_NOT_FOUND',
+}
+
+/**
+ * Retry strategies for different error types
+ */
+export enum RetryStrategy {
+  /** Retry up to 3 times immediately with short delay */
+  IMMEDIATE = 'immediate',
+  /** Wait and retry with increasing delays (2s, 4s, 8s) */
+  EXPONENTIAL_BACKOFF = 'exponential_backoff',
+  /** Requires user action before retrying */
+  MANUAL = 'manual',
+  /** Do not retry - fatal error */
+  NONE = 'none',
+}
+
+/**
+ * Structured deployment error with all context
+ */
+export interface DeploymentError {
+  code: DeploymentErrorCode;
+  message: string;
+  userMessage: string;
+  retryStrategy: RetryStrategy;
+  retryAfterMs?: number;
+  suggestedAction?: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Record of a single retry attempt
+ */
+export interface RetryAttempt {
+  attemptNumber: number;
+  timestamp: string;
+  errorCode: DeploymentErrorCode;
+  errorMessage: string;
+  waitedMs?: number;
+}
+
+/**
+ * Extended deployment metadata for error tracking
+ */
+export interface DeploymentMetadataExtended {
+  options?: Record<string, unknown>;
+  gistId?: string;
+  rawUrl?: string;
+  retryAttempts?: RetryAttempt[];
+  totalRetries?: number;
+  lastRetryAt?: string;
+  rollbackPerformed?: boolean;
+  rollbackReason?: string;
+  suggestedNames?: string[];
+  errorCode?: DeploymentErrorCode;
+  retryStrategy?: RetryStrategy;
+}
+
+/**
+ * Configuration for retry behavior per error code
+ */
+export interface RetryConfig {
+  strategy: RetryStrategy;
+  maxRetries: number;
+  baseDelayMs: number;
+}
+
+/**
+ * Error code to retry strategy mapping
+ */
+export const ERROR_RETRY_CONFIG: Record<DeploymentErrorCode, RetryConfig> = {
+  // Immediate retry - network issues
+  [DeploymentErrorCode.NETWORK_TIMEOUT]: {
+    strategy: RetryStrategy.IMMEDIATE,
+    maxRetries: 3,
+    baseDelayMs: 1000,
+  },
+  [DeploymentErrorCode.CONNECTION_RESET]: {
+    strategy: RetryStrategy.IMMEDIATE,
+    maxRetries: 3,
+    baseDelayMs: 1000,
+  },
+  [DeploymentErrorCode.SERVICE_UNAVAILABLE]: {
+    strategy: RetryStrategy.IMMEDIATE,
+    maxRetries: 3,
+    baseDelayMs: 2000,
+  },
+
+  // Exponential backoff - rate limits
+  [DeploymentErrorCode.RATE_LIMIT_EXCEEDED]: {
+    strategy: RetryStrategy.EXPONENTIAL_BACKOFF,
+    maxRetries: 3,
+    baseDelayMs: 2000,
+  },
+  [DeploymentErrorCode.SECONDARY_RATE_LIMIT]: {
+    strategy: RetryStrategy.EXPONENTIAL_BACKOFF,
+    maxRetries: 3,
+    baseDelayMs: 5000,
+  },
+
+  // Manual retry - code issues
+  [DeploymentErrorCode.INVALID_CODE]: {
+    strategy: RetryStrategy.MANUAL,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+  [DeploymentErrorCode.COMPILATION_ERROR]: {
+    strategy: RetryStrategy.MANUAL,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+  [DeploymentErrorCode.MISSING_DEPENDENCIES]: {
+    strategy: RetryStrategy.MANUAL,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+  [DeploymentErrorCode.INVALID_SERVER_NAME]: {
+    strategy: RetryStrategy.MANUAL,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+
+  // No retry - fatal errors
+  [DeploymentErrorCode.AUTHENTICATION_FAILED]: {
+    strategy: RetryStrategy.NONE,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+  [DeploymentErrorCode.INSUFFICIENT_PERMISSIONS]: {
+    strategy: RetryStrategy.NONE,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+  [DeploymentErrorCode.REPOSITORY_NAME_CONFLICT]: {
+    strategy: RetryStrategy.NONE,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+  [DeploymentErrorCode.GIST_NOT_FOUND]: {
+    strategy: RetryStrategy.NONE,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+  [DeploymentErrorCode.REPOSITORY_NOT_FOUND]: {
+    strategy: RetryStrategy.NONE,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+
+  // Internal errors
+  [DeploymentErrorCode.UNKNOWN_ERROR]: {
+    strategy: RetryStrategy.IMMEDIATE,
+    maxRetries: 1,
+    baseDelayMs: 1000,
+  },
+  [DeploymentErrorCode.NO_FILES_TO_DEPLOY]: {
+    strategy: RetryStrategy.MANUAL,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+  [DeploymentErrorCode.CONVERSATION_NOT_FOUND]: {
+    strategy: RetryStrategy.NONE,
+    maxRetries: 0,
+    baseDelayMs: 0,
+  },
+};
+
+/**
+ * User-friendly error messages for each error code
+ */
+export const ERROR_USER_MESSAGES: Record<DeploymentErrorCode, string> = {
+  [DeploymentErrorCode.NETWORK_TIMEOUT]:
+    'Network timeout. Retrying automatically...',
+  [DeploymentErrorCode.CONNECTION_RESET]:
+    'Connection was reset. Retrying...',
+  [DeploymentErrorCode.SERVICE_UNAVAILABLE]:
+    'GitHub service temporarily unavailable. Retrying...',
+  [DeploymentErrorCode.RATE_LIMIT_EXCEEDED]:
+    'GitHub rate limit reached. Waiting before retry...',
+  [DeploymentErrorCode.SECONDARY_RATE_LIMIT]:
+    'GitHub secondary rate limit hit. Please wait a moment.',
+  [DeploymentErrorCode.INVALID_CODE]:
+    'Generated code has errors. Please regenerate the server.',
+  [DeploymentErrorCode.COMPILATION_ERROR]:
+    'Code compilation failed. Please check the generated code.',
+  [DeploymentErrorCode.MISSING_DEPENDENCIES]:
+    'Missing dependencies detected. Please regenerate.',
+  [DeploymentErrorCode.INVALID_SERVER_NAME]:
+    'Invalid server name. Please use alphanumeric characters and hyphens.',
+  [DeploymentErrorCode.AUTHENTICATION_FAILED]:
+    'GitHub authentication failed. Please check your credentials.',
+  [DeploymentErrorCode.INSUFFICIENT_PERMISSIONS]:
+    'Insufficient GitHub permissions for this operation.',
+  [DeploymentErrorCode.REPOSITORY_NAME_CONFLICT]:
+    'Repository name already exists. Try a different name.',
+  [DeploymentErrorCode.GIST_NOT_FOUND]:
+    'Gist not found. It may have been deleted.',
+  [DeploymentErrorCode.REPOSITORY_NOT_FOUND]:
+    'Repository not found. It may have been deleted.',
+  [DeploymentErrorCode.UNKNOWN_ERROR]:
+    'An unexpected error occurred. Please try again.',
+  [DeploymentErrorCode.NO_FILES_TO_DEPLOY]:
+    'No files to deploy. Please generate the server first.',
+  [DeploymentErrorCode.CONVERSATION_NOT_FOUND]:
+    'Conversation not found.',
+};

--- a/packages/backend/src/deployment/types/deployment.types.ts
+++ b/packages/backend/src/deployment/types/deployment.types.ts
@@ -5,6 +5,7 @@
  */
 
 import { CollectedEnvVar } from '../../types/env-variable.types';
+import { DeploymentErrorCode, RetryStrategy } from './deployment-errors.types';
 
 export type DeploymentType = 'gist' | 'repo' | 'enterprise' | 'none';
 export type DeploymentStatus = 'pending' | 'success' | 'failed';
@@ -39,6 +40,14 @@ export interface DeploymentResult {
   type: DeploymentType;
   urls: DeploymentUrls;
   error?: string;
+  /** Structured error code for programmatic handling */
+  errorCode?: DeploymentErrorCode;
+  /** Recommended retry strategy for this error */
+  retryStrategy?: RetryStrategy;
+  /** Milliseconds to wait before retrying (for rate limits) */
+  retryAfterMs?: number;
+  /** Alternative server names when naming conflict occurs */
+  suggestedNames?: string[];
 }
 
 export interface DeploymentStatusResponse {
@@ -48,6 +57,12 @@ export interface DeploymentStatusResponse {
   status: DeploymentStatus;
   urls: DeploymentUrls;
   errorMessage?: string;
+  /** Structured error code */
+  errorCode?: DeploymentErrorCode;
+  /** Number of retry attempts made */
+  retryCount?: number;
+  /** Whether this deployment can be retried */
+  canRetry?: boolean;
   createdAt: Date;
   deployedAt?: Date;
 }
@@ -117,4 +132,14 @@ export interface PaginatedDeployments {
 export interface DeleteDeploymentResult {
   success: boolean;
   error?: string;
+}
+
+/**
+ * Options for retrying a deployment
+ */
+export interface RetryDeploymentOptions {
+  /** Force retry even if retry strategy says not to */
+  forceRetry?: boolean;
+  /** New server name to use (for naming conflicts) */
+  newServerName?: string;
 }


### PR DESCRIPTION
## Summary

Implements comprehensive error handling for the deployment module (Issue #14):

- **17 categorized error codes** with appropriate retry strategies
- **Automatic retry** with exponential backoff for rate limits and transient failures
- **Rollback functionality** to clean up orphaned repos/gists on failure
- **User-friendly error messages** with actionable suggestions
- **Alternative name suggestions** for repository naming conflicts

## Changes

### New Files
- `deployment-errors.types.ts` - Error codes, retry strategies, user messages
- `retry.service.ts` - Generic retry logic with exponential backoff
- `rollback.service.ts` - Cleanup service for failed deployments

### Modified Files
- `deployment.service.ts` - Integrated retry/rollback, structured error responses
- `deployment.controller.ts` - New retry-by-ID endpoint, error fields in responses
- `gist.provider.ts` - Added rate limit retry logic (matching GitHubRepoProvider)
- `deployment.types.ts` - Added errorCode, retryStrategy, suggestedNames fields
- `deploy-request.dto.ts` - Added retry options and error response fields
- `deployment.module.ts` - Registered new services

## Error Handling Strategy

| Error Type | Retry Strategy | Example |
|------------|----------------|---------|
| Network issues | Immediate (3x) | Timeout, connection reset |
| Rate limits | Exponential backoff | GitHub 403/429 |
| Code issues | Manual | Compilation errors |
| Fatal errors | None | Auth failed, repo exists |

## Test plan

- [ ] Test deployment with simulated rate limit (verify exponential backoff)
- [ ] Test deployment with invalid repo name (verify suggested alternatives)
- [ ] Test retry endpoint with failed deployment
- [ ] Verify rollback cleans up partially created resources

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)