### PR TITLE
feat(subscription): Add tiered deployment strategy with Stripe integration

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -45,6 +45,7 @@
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
     "@octokit/rest": "^20.0.2",
+    "@types/libsodium-wrappers": "^0.7.14",
     "axios": "^1.13.2",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",
@@ -56,11 +57,13 @@
     "joi": "^17.12.0",
     "js-yaml": "^4.1.0",
     "langchain": "^0.3.35",
+    "libsodium-wrappers": "^0.7.15",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.11.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "stripe": "^20.0.0",
     "tar-fs": "^3.0.4",
     "typeorm": "^0.3.17",
     "uuid": "^9.0.1"
@@ -109,7 +112,10 @@
           "compiler": "typescript",
           "tsconfig": {
             "module": "commonjs",
-            "types": ["jest", "node"],
+            "types": [
+              "jest",
+              "node"
+            ],
             "emitDecoratorMetadata": true,
             "experimentalDecorators": true,
             "allowSyntheticDefaultImports": true,

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -12,7 +12,9 @@ import { McpGenerationService } from './mcp-generation.service';
 import { ChatModule } from './chat/chat.module';
 import { DeploymentModule } from './deployment/deployment.module';
 import { ValidationModule } from './validation/validation.module';
-import { Conversation, ConversationMemory, Deployment } from './database/entities';
+import { UserModule } from './user/user.module';
+import { SubscriptionModule } from './subscription/subscription.module';
+import { Conversation, ConversationMemory, Deployment, User, Subscription, UsageRecord } from './database/entities';
 
 // Basic DTO for generate endpoint
 export class GenerateServerDto {
@@ -285,7 +287,7 @@ main().catch((error) => {
       username: process.env.DATABASE_USER || 'postgres',
       password: process.env.DATABASE_PASSWORD || 'postgres',
       database: process.env.DATABASE_NAME || 'mcp_everything',
-      entities: [Conversation, ConversationMemory, Deployment],
+      entities: [Conversation, ConversationMemory, Deployment, User, Subscription, UsageRecord],
       synchronize: process.env.NODE_ENV !== 'production', // Auto-sync in development
       logging: process.env.NODE_ENV === 'development',
     }),
@@ -293,6 +295,8 @@ main().catch((error) => {
     ChatModule,
     DeploymentModule,
     ValidationModule,
+    UserModule,
+    SubscriptionModule,
   ],
   controllers: [AppController],
   providers: [

--- a/packages/backend/src/database/entities/conversation.entity.ts
+++ b/packages/backend/src/database/entities/conversation.entity.ts
@@ -1,9 +1,18 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, Index, ManyToOne, JoinColumn } from 'typeorm';
+import { User } from './user.entity';
 
 @Entity('conversations')
 export class Conversation {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  @Index('IDX_conversations_userId')
+  userId?: string;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'userId' })
+  user?: User;
 
   @Column({ type: 'varchar', length: 255 })
   @Index()

--- a/packages/backend/src/database/entities/deployment.entity.ts
+++ b/packages/backend/src/database/entities/deployment.entity.ts
@@ -8,6 +8,7 @@ import {
   Index,
 } from 'typeorm';
 import { Conversation } from './conversation.entity';
+import { User } from './user.entity';
 
 @Entity('deployments')
 export class Deployment {
@@ -21,6 +22,17 @@ export class Deployment {
   @ManyToOne(() => Conversation, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'conversationId' })
   conversation: Conversation;
+
+  @Column({ type: 'uuid', nullable: true })
+  @Index('IDX_deployments_userId')
+  userId?: string;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'userId' })
+  user?: User;
+
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  userTier?: 'free' | 'pro' | 'enterprise';
 
   @Column({ type: 'varchar', length: 20 })
   deploymentType: 'gist' | 'repo' | 'none';

--- a/packages/backend/src/database/entities/index.ts
+++ b/packages/backend/src/database/entities/index.ts
@@ -2,3 +2,6 @@ export { Conversation } from './conversation.entity';
 export { ConversationMemory } from './conversation-memory.entity';
 export { ResearchCache } from './research-cache.entity';
 export { Deployment } from './deployment.entity';
+export { User } from './user.entity';
+export { Subscription } from './subscription.entity';
+export { UsageRecord } from './usage.entity';

--- a/packages/backend/src/database/entities/subscription.entity.ts
+++ b/packages/backend/src/database/entities/subscription.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('subscriptions')
+export class Subscription {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  @Index('IDX_subscriptions_userId')
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'varchar', length: 255 })
+  @Index('IDX_subscriptions_stripeCustomerId')
+  stripeCustomerId: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  @Index('IDX_subscriptions_stripeSubscriptionId')
+  stripeSubscriptionId?: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  stripePriceId?: string;
+
+  @Column({ type: 'varchar', length: 20, default: 'free' })
+  tier: 'free' | 'pro' | 'enterprise';
+
+  @Column({ type: 'varchar', length: 20, default: 'active' })
+  @Index('IDX_subscriptions_status')
+  status: 'active' | 'canceled' | 'past_due' | 'incomplete' | 'trialing';
+
+  @Column({ type: 'timestamp', nullable: true })
+  currentPeriodStart?: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  currentPeriodEnd?: Date;
+
+  @Column({ type: 'boolean', default: false })
+  cancelAtPeriodEnd: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  canceledAt?: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/packages/backend/src/database/entities/usage.entity.ts
+++ b/packages/backend/src/database/entities/usage.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('usage_records')
+export class UsageRecord {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  @Index('IDX_usage_userId')
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'int', default: 0 })
+  serversDeployedThisMonth: number;
+
+  @Column({ type: 'int', default: 5 })
+  monthlyLimit: number;
+
+  @Column({ type: 'timestamp' })
+  @Index('IDX_usage_periodStart')
+  periodStart: Date;
+
+  @Column({ type: 'timestamp' })
+  @Index('IDX_usage_periodEnd')
+  periodEnd: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/packages/backend/src/database/entities/user.entity.ts
+++ b/packages/backend/src/database/entities/user.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  OneToMany,
+  Index,
+} from 'typeorm';
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255, unique: true })
+  @Index('IDX_users_email')
+  email: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  passwordHash?: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  firstName?: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  lastName?: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  githubUsername?: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  @Index('IDX_users_githubId')
+  githubId?: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  @Index('IDX_users_googleId')
+  googleId?: string;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @Column({ type: 'boolean', default: false })
+  isEmailVerified: boolean;
+
+  @Column({ type: 'varchar', length: 20, default: 'free' })
+  @Index('IDX_users_tier')
+  tier: 'free' | 'pro' | 'enterprise';
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastLoginAt?: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/packages/backend/src/database/migrations/1733100000000-AddUserTierSystem.ts
+++ b/packages/backend/src/database/migrations/1733100000000-AddUserTierSystem.ts
@@ -1,0 +1,124 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserTierSystem1733100000000 implements MigrationInterface {
+  name = 'AddUserTierSystem1733100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Enable UUID extension if not exists
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+
+    // Create users table
+    await queryRunner.query(`
+      CREATE TABLE "users" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "email" varchar(255) UNIQUE NOT NULL,
+        "passwordHash" varchar(255),
+        "firstName" varchar(100),
+        "lastName" varchar(100),
+        "githubUsername" varchar(100),
+        "githubId" varchar(255),
+        "googleId" varchar(255),
+        "isActive" boolean DEFAULT true,
+        "isEmailVerified" boolean DEFAULT false,
+        "tier" varchar(20) DEFAULT 'free',
+        "lastLoginAt" timestamp,
+        "createdAt" timestamp DEFAULT now(),
+        "updatedAt" timestamp DEFAULT now()
+      )
+    `);
+
+    // Create subscriptions table
+    await queryRunner.query(`
+      CREATE TABLE "subscriptions" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "stripeCustomerId" varchar(255) NOT NULL,
+        "stripeSubscriptionId" varchar(255),
+        "stripePriceId" varchar(255),
+        "tier" varchar(20) DEFAULT 'free',
+        "status" varchar(20) DEFAULT 'active',
+        "currentPeriodStart" timestamp,
+        "currentPeriodEnd" timestamp,
+        "cancelAtPeriodEnd" boolean DEFAULT false,
+        "canceledAt" timestamp,
+        "createdAt" timestamp DEFAULT now(),
+        "updatedAt" timestamp DEFAULT now()
+      )
+    `);
+
+    // Create usage_records table
+    await queryRunner.query(`
+      CREATE TABLE "usage_records" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+        "serversDeployedThisMonth" int DEFAULT 0,
+        "monthlyLimit" int DEFAULT 5,
+        "periodStart" timestamp NOT NULL,
+        "periodEnd" timestamp NOT NULL,
+        "createdAt" timestamp DEFAULT now(),
+        "updatedAt" timestamp DEFAULT now()
+      )
+    `);
+
+    // Add userId and userTier columns to deployments table
+    await queryRunner.query(`ALTER TABLE "deployments" ADD COLUMN "userId" uuid REFERENCES "users"("id") ON DELETE SET NULL`);
+    await queryRunner.query(`ALTER TABLE "deployments" ADD COLUMN "userTier" varchar(20)`);
+
+    // Add userId column to conversations table
+    await queryRunner.query(`ALTER TABLE "conversations" ADD COLUMN "userId" uuid REFERENCES "users"("id") ON DELETE SET NULL`);
+
+    // Create indexes for users table
+    await queryRunner.query(`CREATE INDEX "IDX_users_email" ON "users"("email")`);
+    await queryRunner.query(`CREATE INDEX "IDX_users_tier" ON "users"("tier")`);
+    await queryRunner.query(`CREATE INDEX "IDX_users_githubId" ON "users"("githubId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_users_googleId" ON "users"("googleId")`);
+
+    // Create indexes for subscriptions table
+    await queryRunner.query(`CREATE INDEX "IDX_subscriptions_userId" ON "subscriptions"("userId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_subscriptions_status" ON "subscriptions"("status")`);
+    await queryRunner.query(`CREATE INDEX "IDX_subscriptions_stripeCustomerId" ON "subscriptions"("stripeCustomerId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_subscriptions_stripeSubscriptionId" ON "subscriptions"("stripeSubscriptionId")`);
+
+    // Create indexes for usage_records table
+    await queryRunner.query(`CREATE INDEX "IDX_usage_userId" ON "usage_records"("userId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_usage_periodStart" ON "usage_records"("periodStart")`);
+    await queryRunner.query(`CREATE INDEX "IDX_usage_periodEnd" ON "usage_records"("periodEnd")`);
+
+    // Create indexes for new columns on existing tables
+    await queryRunner.query(`CREATE INDEX "IDX_deployments_userId" ON "deployments"("userId")`);
+    await queryRunner.query(`CREATE INDEX "IDX_conversations_userId" ON "conversations"("userId")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop indexes for new columns on existing tables
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_conversations_userId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_deployments_userId"`);
+
+    // Drop indexes for usage_records table
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_usage_periodEnd"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_usage_periodStart"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_usage_userId"`);
+
+    // Drop indexes for subscriptions table
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_subscriptions_stripeSubscriptionId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_subscriptions_stripeCustomerId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_subscriptions_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_subscriptions_userId"`);
+
+    // Drop indexes for users table
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_users_googleId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_users_githubId"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_users_tier"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_users_email"`);
+
+    // Drop columns from existing tables
+    await queryRunner.query(`ALTER TABLE "conversations" DROP COLUMN IF EXISTS "userId"`);
+    await queryRunner.query(`ALTER TABLE "deployments" DROP COLUMN IF EXISTS "userTier"`);
+    await queryRunner.query(`ALTER TABLE "deployments" DROP COLUMN IF EXISTS "userId"`);
+
+    // Drop new tables
+    await queryRunner.query(`DROP TABLE IF EXISTS "usage_records"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "subscriptions"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "users"`);
+  }
+}

--- a/packages/backend/src/deployment/deployment.module.ts
+++ b/packages/backend/src/deployment/deployment.module.ts
@@ -14,9 +14,11 @@ import { DevContainerProvider } from './providers/devcontainer.provider';
 import { GitignoreProvider } from './providers/gitignore.provider';
 import { CIWorkflowProvider } from './providers/ci-workflow.provider';
 import { ValidationModule } from '../validation/validation.module';
+import { UserModule } from '../user/user.module';
 
 import { DeploymentRetryService } from './services/retry.service';
 import { DeploymentRollbackService } from './services/rollback.service';
+import { DeploymentRouterService } from './services/deployment-router.service';
 
 @Module({
   imports: [
@@ -28,6 +30,8 @@ import { DeploymentRollbackService } from './services/rollback.service';
     }]),
     // Import ValidationModule for post-deployment validation
     forwardRef(() => ValidationModule),
+    // Import UserModule for tier-based routing
+    forwardRef(() => UserModule),
   ],
   controllers: [DeploymentController],
   providers: [
@@ -39,7 +43,8 @@ import { DeploymentRollbackService } from './services/rollback.service';
     CIWorkflowProvider,
     DeploymentRetryService,
     DeploymentRollbackService,
+    DeploymentRouterService,
   ],
-  exports: [DeploymentOrchestratorService, DeploymentRetryService],
+  exports: [DeploymentOrchestratorService, DeploymentRetryService, DeploymentRouterService],
 })
 export class DeploymentModule {}

--- a/packages/backend/src/deployment/services/deployment-router.service.ts
+++ b/packages/backend/src/deployment/services/deployment-router.service.ts
@@ -1,0 +1,209 @@
+import { Injectable, Logger, ForbiddenException, Inject, forwardRef } from '@nestjs/common';
+import { UserService } from '../../user/user.service';
+import { DeploymentOrchestratorService } from '../deployment.service';
+import { DeploymentResult, DeploymentOptions, EnterpriseDeploymentOptions } from '../types/deployment.types';
+import { UserTier, TIER_CONFIG, TIER_DISPLAY_NAMES } from '../../subscription/tier-config';
+
+export interface TierRestrictedDeploymentOptions extends DeploymentOptions {
+  deploymentType?: 'gist' | 'repo' | 'enterprise';
+  // Enterprise-specific options
+  customDomain?: string;
+  region?: string;
+  enableCdn?: boolean;
+}
+
+export interface DeploymentLimitError {
+  code: 'LIMIT_EXCEEDED' | 'TIER_RESTRICTION' | 'USER_NOT_FOUND';
+  message: string;
+  currentUsage?: number;
+  limit?: number;
+  currentTier?: string;
+  requiredTier?: string;
+  upgradeUrl: string;
+}
+
+@Injectable()
+export class DeploymentRouterService {
+  private readonly logger = new Logger(DeploymentRouterService.name);
+
+  constructor(
+    private readonly userService: UserService,
+    @Inject(forwardRef(() => DeploymentOrchestratorService))
+    private readonly deploymentService: DeploymentOrchestratorService,
+  ) {}
+
+  async routeDeployment(
+    userId: string,
+    conversationId: string,
+    options: TierRestrictedDeploymentOptions = {},
+  ): Promise<DeploymentResult> {
+    // 1. Get user and their tier
+    const user = await this.userService.findById(userId);
+    if (!user) {
+      throw new ForbiddenException({
+        code: 'USER_NOT_FOUND',
+        message: 'User not found',
+        upgradeUrl: '/account',
+      } as DeploymentLimitError);
+    }
+
+    const tierConfig = TIER_CONFIG[user.tier as UserTier];
+    this.logger.log(`Routing deployment for user ${userId} (tier: ${user.tier})`);
+
+    // 2. Check usage limits
+    const canDeploy = await this.userService.checkCanDeploy(userId);
+    if (!canDeploy.allowed) {
+      throw new ForbiddenException({
+        code: 'LIMIT_EXCEEDED',
+        message: canDeploy.reason,
+        currentUsage: canDeploy.usage?.serversDeployedThisMonth,
+        limit: canDeploy.usage?.monthlyLimit,
+        currentTier: user.tier,
+        upgradeUrl: '/account?upgrade=true',
+      } as DeploymentLimitError);
+    }
+
+    // 3. Determine deployment type
+    const requestedType = options.deploymentType || this.getDefaultDeploymentType(user.tier as UserTier);
+
+    // 4. Validate deployment type for tier
+    if (!tierConfig.deploymentTypes.includes(requestedType)) {
+      const requiredTier = this.getRequiredTierForDeploymentType(requestedType);
+      throw new ForbiddenException({
+        code: 'TIER_RESTRICTION',
+        message: `${this.formatDeploymentType(requestedType)} deployment requires ${TIER_DISPLAY_NAMES[requiredTier]} tier or higher`,
+        currentTier: user.tier,
+        requiredTier,
+        upgradeUrl: '/account?upgrade=true',
+      } as DeploymentLimitError);
+    }
+
+    // 5. Apply tier-specific options
+    const deployOptions: DeploymentOptions = {
+      ...options,
+      // Free tier: always public gists
+      isPrivate: tierConfig.privateRepos ? (options.isPrivate ?? true) : false,
+    };
+
+    // 6. Execute deployment based on type
+    let result: DeploymentResult;
+    try {
+      switch (requestedType) {
+        case 'gist':
+          result = await this.deploymentService.deployToGist(conversationId, deployOptions);
+          break;
+        case 'repo':
+          result = await this.deploymentService.deployToGitHub(conversationId, deployOptions);
+          break;
+        case 'enterprise':
+          const enterpriseOptions: EnterpriseDeploymentOptions = {
+            customDomain: options.customDomain,
+            region: options.region,
+            enableCdn: options.enableCdn,
+          };
+          result = await this.deploymentService.deployToEnterprise(conversationId, enterpriseOptions);
+          break;
+        default:
+          result = await this.deploymentService.deployToGist(conversationId, deployOptions);
+      }
+    } catch (error) {
+      this.logger.error(`Deployment failed for user ${userId}: ${error.message}`);
+      throw error;
+    }
+
+    // 7. Increment usage on success
+    if (result.success) {
+      await this.userService.incrementUsage(userId);
+      this.logger.log(`Deployment successful, incremented usage for user ${userId}`);
+    }
+
+    return result;
+  }
+
+  async checkDeploymentPermission(
+    userId: string,
+    deploymentType: 'gist' | 'repo' | 'enterprise',
+  ): Promise<{ allowed: boolean; error?: DeploymentLimitError }> {
+    const user = await this.userService.findById(userId);
+    if (!user) {
+      return {
+        allowed: false,
+        error: {
+          code: 'USER_NOT_FOUND',
+          message: 'User not found',
+          upgradeUrl: '/account',
+        },
+      };
+    }
+
+    const tierConfig = TIER_CONFIG[user.tier as UserTier];
+
+    // Check usage limits
+    const canDeploy = await this.userService.checkCanDeploy(userId);
+    if (!canDeploy.allowed) {
+      return {
+        allowed: false,
+        error: {
+          code: 'LIMIT_EXCEEDED',
+          message: canDeploy.reason!,
+          currentUsage: canDeploy.usage?.serversDeployedThisMonth,
+          limit: canDeploy.usage?.monthlyLimit,
+          currentTier: user.tier,
+          upgradeUrl: '/account?upgrade=true',
+        },
+      };
+    }
+
+    // Check deployment type permission
+    if (!tierConfig.deploymentTypes.includes(deploymentType)) {
+      const requiredTier = this.getRequiredTierForDeploymentType(deploymentType);
+      return {
+        allowed: false,
+        error: {
+          code: 'TIER_RESTRICTION',
+          message: `${this.formatDeploymentType(deploymentType)} deployment requires ${TIER_DISPLAY_NAMES[requiredTier]} tier or higher`,
+          currentTier: user.tier,
+          requiredTier,
+          upgradeUrl: '/account?upgrade=true',
+        },
+      };
+    }
+
+    return { allowed: true };
+  }
+
+  private getDefaultDeploymentType(tier: UserTier): 'gist' | 'repo' | 'enterprise' {
+    switch (tier) {
+      case UserTier.ENTERPRISE:
+        return 'repo';
+      case UserTier.PRO:
+        return 'repo';
+      default:
+        return 'gist';
+    }
+  }
+
+  private getRequiredTierForDeploymentType(deploymentType: string): UserTier {
+    switch (deploymentType) {
+      case 'enterprise':
+        return UserTier.ENTERPRISE;
+      case 'repo':
+        return UserTier.PRO;
+      default:
+        return UserTier.FREE;
+    }
+  }
+
+  private formatDeploymentType(type: string): string {
+    switch (type) {
+      case 'gist':
+        return 'GitHub Gist';
+      case 'repo':
+        return 'Private Repository';
+      case 'enterprise':
+        return 'Enterprise';
+      default:
+        return type;
+    }
+  }
+}

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -5,7 +5,10 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const logger = new Logger('Bootstrap');
 
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    // Enable raw body for Stripe webhooks
+    rawBody: true,
+  });
 
   // Enable CORS for frontend with SSE-specific configuration
   app.enableCors({

--- a/packages/backend/src/subscription/dto/subscription.dto.ts
+++ b/packages/backend/src/subscription/dto/subscription.dto.ts
@@ -1,0 +1,56 @@
+import { IsString, IsOptional, IsIn } from 'class-validator';
+
+export class CreateCheckoutDto {
+  @IsString()
+  @IsIn(['pro', 'enterprise'])
+  tier: 'pro' | 'enterprise';
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['monthly', 'yearly'])
+  interval?: 'monthly' | 'yearly';
+}
+
+export interface SubscriptionDto {
+  tier: 'free' | 'pro' | 'enterprise';
+  status: string;
+  currentPeriodStart?: Date;
+  currentPeriodEnd?: Date;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface UsageDto {
+  serversDeployedThisMonth: number;
+  monthlyLimit: number;
+  periodStart: Date;
+  periodEnd: Date;
+  percentUsed: number;
+  remainingDeployments: number;
+}
+
+export interface TierInfoDto {
+  currentTier: 'free' | 'pro' | 'enterprise';
+  limits: {
+    monthlyServerLimit: number;
+    privateRepos: boolean;
+    ciCd: boolean;
+    customDomains: boolean;
+    sla: boolean;
+    prioritySupport: boolean;
+  };
+  usage: {
+    serversDeployed: number;
+    limit: number;
+    periodEnd: Date;
+  };
+  canUpgrade: boolean;
+}
+
+export interface CheckoutSessionDto {
+  sessionId: string;
+  url: string;
+}
+
+export interface PortalSessionDto {
+  url: string;
+}

--- a/packages/backend/src/subscription/stripe-webhook.controller.ts
+++ b/packages/backend/src/subscription/stripe-webhook.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  Post,
+  Headers,
+  Req,
+  HttpCode,
+  Logger,
+  BadRequestException,
+  RawBodyRequest,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { StripeService } from './stripe.service';
+import { SubscriptionService } from './subscription.service';
+
+@Controller('api/webhooks/stripe')
+export class StripeWebhookController {
+  private readonly logger = new Logger(StripeWebhookController.name);
+
+  constructor(
+    private readonly stripeService: StripeService,
+    private readonly subscriptionService: SubscriptionService,
+  ) {}
+
+  @Post()
+  @HttpCode(200)
+  async handleWebhook(
+    @Headers('stripe-signature') signature: string,
+    @Req() req: RawBodyRequest<Request>,
+  ): Promise<{ received: boolean }> {
+    if (!signature) {
+      throw new BadRequestException('Missing stripe-signature header');
+    }
+
+    if (!req.rawBody) {
+      throw new BadRequestException('Missing raw body - ensure raw body parsing is enabled');
+    }
+
+    let event: any;
+
+    try {
+      event = this.stripeService.constructWebhookEvent(req.rawBody, signature);
+    } catch (err) {
+      this.logger.error(`Webhook signature verification failed: ${(err as Error).message}`);
+      throw new BadRequestException(`Webhook signature verification failed: ${(err as Error).message}`);
+    }
+
+    this.logger.log(`Processing webhook event: ${event.type} (${event.id})`);
+
+    try {
+      switch (event.type) {
+        case 'customer.subscription.created':
+          await this.subscriptionService.handleSubscriptionCreated(event.data.object);
+          break;
+
+        case 'customer.subscription.updated':
+          await this.subscriptionService.handleSubscriptionUpdated(event.data.object);
+          break;
+
+        case 'customer.subscription.deleted':
+          await this.subscriptionService.handleSubscriptionDeleted(event.data.object);
+          break;
+
+        case 'invoice.payment_succeeded':
+          await this.subscriptionService.handleInvoicePaymentSucceeded(event.data.object);
+          break;
+
+        case 'invoice.payment_failed':
+          await this.subscriptionService.handleInvoicePaymentFailed(event.data.object);
+          break;
+
+        case 'checkout.session.completed':
+          this.logger.log(`Checkout session completed: ${event.data.object.id}`);
+          // Subscription handling is done via subscription.created webhook
+          break;
+
+        default:
+          this.logger.log(`Unhandled event type: ${event.type}`);
+      }
+    } catch (error) {
+      this.logger.error(`Error processing webhook ${event.type}: ${(error as Error).message}`, (error as Error).stack);
+      // Don't throw - return 200 to acknowledge receipt
+      // Stripe will retry on errors, so we want to prevent infinite retries for processing errors
+    }
+
+    return { received: true };
+  }
+}

--- a/packages/backend/src/subscription/stripe.service.ts
+++ b/packages/backend/src/subscription/stripe.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Stripe from 'stripe';
+
+@Injectable()
+export class StripeService {
+  private readonly logger = new Logger(StripeService.name);
+  private stripe: Stripe | null = null;
+
+  constructor(private readonly configService: ConfigService) {
+    const secretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
+    if (secretKey) {
+      this.stripe = new Stripe(secretKey);
+      this.logger.log('Stripe client initialized');
+    } else {
+      this.logger.warn('STRIPE_SECRET_KEY not configured - Stripe features will be disabled');
+    }
+  }
+
+  private ensureStripeConfigured(): Stripe {
+    if (!this.stripe) {
+      throw new BadRequestException('Stripe is not configured');
+    }
+    return this.stripe;
+  }
+
+  async createCustomer(email: string, metadata?: Record<string, string>): Promise<Stripe.Customer> {
+    const stripe = this.ensureStripeConfigured();
+    this.logger.log(`Creating Stripe customer for: ${email}`);
+    return stripe.customers.create({
+      email,
+      metadata,
+    });
+  }
+
+  async getCustomer(customerId: string): Promise<Stripe.Customer | Stripe.DeletedCustomer> {
+    const stripe = this.ensureStripeConfigured();
+    return stripe.customers.retrieve(customerId);
+  }
+
+  async createCheckoutSession(
+    customerId: string,
+    priceId: string,
+    successUrl: string,
+    cancelUrl: string,
+  ): Promise<Stripe.Checkout.Session> {
+    const stripe = this.ensureStripeConfigured();
+    this.logger.log(`Creating checkout session for customer: ${customerId}`);
+    return stripe.checkout.sessions.create({
+      customer: customerId,
+      mode: 'subscription',
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: successUrl,
+      cancel_url: cancelUrl,
+      subscription_data: {
+        metadata: { customerId },
+      },
+    });
+  }
+
+  async createBillingPortalSession(
+    customerId: string,
+    returnUrl: string,
+  ): Promise<Stripe.BillingPortal.Session> {
+    const stripe = this.ensureStripeConfigured();
+    this.logger.log(`Creating billing portal session for customer: ${customerId}`);
+    return stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: returnUrl,
+    });
+  }
+
+  async getSubscription(subscriptionId: string): Promise<Stripe.Subscription> {
+    const stripe = this.ensureStripeConfigured();
+    return stripe.subscriptions.retrieve(subscriptionId);
+  }
+
+  async cancelSubscription(
+    subscriptionId: string,
+    immediately = false,
+  ): Promise<Stripe.Subscription> {
+    const stripe = this.ensureStripeConfigured();
+    this.logger.log(`Canceling subscription: ${subscriptionId} (immediately: ${immediately})`);
+    if (immediately) {
+      return stripe.subscriptions.cancel(subscriptionId);
+    }
+    return stripe.subscriptions.update(subscriptionId, {
+      cancel_at_period_end: true,
+    });
+  }
+
+  async resumeSubscription(subscriptionId: string): Promise<Stripe.Subscription> {
+    const stripe = this.ensureStripeConfigured();
+    this.logger.log(`Resuming subscription: ${subscriptionId}`);
+    return stripe.subscriptions.update(subscriptionId, {
+      cancel_at_period_end: false,
+    });
+  }
+
+  constructWebhookEvent(payload: Buffer, signature: string): Stripe.Event {
+    const stripe = this.ensureStripeConfigured();
+    const webhookSecret = this.configService.get<string>('STRIPE_WEBHOOK_SECRET');
+    if (!webhookSecret) {
+      throw new BadRequestException('Webhook secret not configured');
+    }
+    return stripe.webhooks.constructEvent(payload, signature, webhookSecret);
+  }
+
+  isConfigured(): boolean {
+    return this.stripe !== null;
+  }
+}

--- a/packages/backend/src/subscription/subscription.controller.ts
+++ b/packages/backend/src/subscription/subscription.controller.ts
@@ -1,0 +1,114 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { SubscriptionService } from './subscription.service';
+import { UserService } from '../user/user.service';
+import { CreateCheckoutDto, SubscriptionDto, UsageDto, TierInfoDto } from './dto/subscription.dto';
+import { TIER_CONFIG, UserTier } from './tier-config';
+import { User } from '../database/entities/user.entity';
+
+// TODO: Replace with proper auth guard once authentication is implemented
+function getCurrentUser(req: Request): User | null {
+  return (req as any).user || null;
+}
+
+@Controller('api/subscription')
+export class SubscriptionController {
+  constructor(
+    private readonly subscriptionService: SubscriptionService,
+    private readonly userService: UserService,
+  ) {}
+
+  @Get()
+  async getSubscription(@Req() req: Request): Promise<SubscriptionDto> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    const subscription = await this.subscriptionService.getActiveSubscription(user.id);
+    return {
+      tier: (user.tier as 'free' | 'pro' | 'enterprise') || 'free',
+      status: subscription?.status || 'active',
+      currentPeriodStart: subscription?.currentPeriodStart,
+      currentPeriodEnd: subscription?.currentPeriodEnd,
+      cancelAtPeriodEnd: subscription?.cancelAtPeriodEnd || false,
+    };
+  }
+
+  @Get('tier')
+  async getTierInfo(@Req() req: Request): Promise<TierInfoDto> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    const usage = await this.userService.getCurrentUsage(user.id);
+    const tierConfig = TIER_CONFIG[(user.tier as UserTier) || UserTier.FREE];
+
+    return {
+      currentTier: (user.tier as 'free' | 'pro' | 'enterprise') || 'free',
+      limits: {
+        monthlyServerLimit: tierConfig.monthlyServerLimit === Infinity ? 999999 : tierConfig.monthlyServerLimit,
+        privateRepos: tierConfig.privateRepos,
+        ciCd: tierConfig.ciCd,
+        customDomains: tierConfig.customDomains,
+        sla: tierConfig.sla,
+        prioritySupport: tierConfig.prioritySupport,
+      },
+      usage: {
+        serversDeployed: usage.serversDeployedThisMonth,
+        limit: usage.monthlyLimit,
+        periodEnd: usage.periodEnd,
+      },
+      canUpgrade: user.tier !== UserTier.ENTERPRISE,
+    };
+  }
+
+  @Get('usage')
+  async getUsage(@Req() req: Request): Promise<UsageDto> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    return this.userService.getUsageStats(user.id);
+  }
+
+  @Post('checkout')
+  @HttpCode(HttpStatus.OK)
+  async createCheckout(
+    @Req() req: Request,
+    @Body() dto: CreateCheckoutDto,
+  ): Promise<{ sessionId: string; url: string }> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    return this.subscriptionService.createCheckoutSession(
+      user.id,
+      dto.tier,
+      dto.interval || 'monthly',
+    );
+  }
+
+  @Post('portal')
+  @HttpCode(HttpStatus.OK)
+  async createPortal(@Req() req: Request): Promise<{ url: string }> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    return this.subscriptionService.createPortalSession(user.id);
+  }
+}

--- a/packages/backend/src/subscription/subscription.module.ts
+++ b/packages/backend/src/subscription/subscription.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { Subscription } from '../database/entities/subscription.entity';
+import { StripeService } from './stripe.service';
+import { SubscriptionService } from './subscription.service';
+import { SubscriptionController } from './subscription.controller';
+import { StripeWebhookController } from './stripe-webhook.controller';
+import { UserModule } from '../user/user.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Subscription]),
+    ConfigModule,
+    UserModule,
+  ],
+  controllers: [SubscriptionController, StripeWebhookController],
+  providers: [StripeService, SubscriptionService],
+  exports: [StripeService, SubscriptionService],
+})
+export class SubscriptionModule {}

--- a/packages/backend/src/subscription/subscription.service.ts
+++ b/packages/backend/src/subscription/subscription.service.ts
@@ -1,0 +1,248 @@
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Subscription } from '../database/entities/subscription.entity';
+import { UserService } from '../user/user.service';
+import { StripeService } from './stripe.service';
+import { UserTier, STRIPE_PRICES, getTierFromPriceId } from './tier-config';
+
+// Stripe webhook event types - using any for flexibility with Stripe API changes
+interface StripeSubscriptionData {
+  id: string;
+  customer: string;
+  current_period_start: number;
+  current_period_end: number;
+  cancel_at_period_end: boolean;
+  status: string;
+  items: {
+    data: Array<{
+      price: { id: string };
+    }>;
+  };
+}
+
+interface StripeInvoiceData {
+  id: string;
+  subscription: string | null;
+}
+
+@Injectable()
+export class SubscriptionService {
+  private readonly logger = new Logger(SubscriptionService.name);
+
+  constructor(
+    @InjectRepository(Subscription)
+    private readonly subscriptionRepository: Repository<Subscription>,
+    private readonly userService: UserService,
+    private readonly stripeService: StripeService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async getActiveSubscription(userId: string): Promise<Subscription | null> {
+    return this.subscriptionRepository.findOne({
+      where: { userId, status: 'active' },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async getSubscriptionByStripeId(stripeSubscriptionId: string): Promise<Subscription | null> {
+    return this.subscriptionRepository.findOne({
+      where: { stripeSubscriptionId },
+    });
+  }
+
+  async getSubscriptionByCustomerId(stripeCustomerId: string): Promise<Subscription | null> {
+    return this.subscriptionRepository.findOne({
+      where: { stripeCustomerId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async createCheckoutSession(
+    userId: string,
+    tier: 'pro' | 'enterprise',
+    interval: 'monthly' | 'yearly' = 'monthly',
+  ): Promise<{ sessionId: string; url: string }> {
+    if (!this.stripeService.isConfigured()) {
+      throw new BadRequestException('Stripe is not configured');
+    }
+
+    const user = await this.userService.findById(userId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Get or create Stripe customer
+    let subscription = await this.getActiveSubscription(userId);
+    let customerId = subscription?.stripeCustomerId;
+
+    if (!customerId) {
+      const customer = await this.stripeService.createCustomer(user.email, { userId });
+      customerId = customer.id;
+
+      // Create subscription record with customer ID
+      subscription = this.subscriptionRepository.create({
+        userId,
+        stripeCustomerId: customerId,
+        tier: UserTier.FREE,
+        status: 'incomplete',
+      });
+      await this.subscriptionRepository.save(subscription);
+    }
+
+    // Get price ID based on tier and interval
+    let priceId: string;
+    if (tier === 'pro') {
+      priceId = interval === 'yearly' ? STRIPE_PRICES.PRO_YEARLY.priceId : STRIPE_PRICES.PRO_MONTHLY.priceId;
+    } else {
+      priceId = STRIPE_PRICES.ENTERPRISE_MONTHLY.priceId;
+    }
+
+    const frontendUrl = this.configService.get<string>('FRONTEND_URL') || 'http://localhost:4200';
+    const session = await this.stripeService.createCheckoutSession(
+      customerId,
+      priceId,
+      `${frontendUrl}/account?session_id={CHECKOUT_SESSION_ID}&success=true`,
+      `${frontendUrl}/account?canceled=true`,
+    );
+
+    this.logger.log(`Created checkout session for user ${userId}: ${session.id}`);
+    return { sessionId: session.id, url: session.url! };
+  }
+
+  async createPortalSession(userId: string): Promise<{ url: string }> {
+    if (!this.stripeService.isConfigured()) {
+      throw new BadRequestException('Stripe is not configured');
+    }
+
+    const subscription = await this.getActiveSubscription(userId);
+    if (!subscription?.stripeCustomerId) {
+      throw new NotFoundException('No active subscription found');
+    }
+
+    const frontendUrl = this.configService.get<string>('FRONTEND_URL') || 'http://localhost:4200';
+    const session = await this.stripeService.createBillingPortalSession(
+      subscription.stripeCustomerId,
+      `${frontendUrl}/account`,
+    );
+
+    this.logger.log(`Created portal session for user ${userId}`);
+    return { url: session.url };
+  }
+
+  async handleSubscriptionCreated(stripeSubscription: StripeSubscriptionData): Promise<void> {
+    this.logger.log(`Handling subscription created: ${stripeSubscription.id}`);
+
+    const customerId = stripeSubscription.customer as string;
+    let subscription = await this.getSubscriptionByCustomerId(customerId);
+
+    if (!subscription) {
+      this.logger.warn(`No subscription record found for customer: ${customerId}`);
+      return;
+    }
+
+    // Determine tier from price ID
+    const priceId = stripeSubscription.items.data[0]?.price.id;
+    const tier = getTierFromPriceId(priceId);
+
+    // Update subscription
+    subscription.stripeSubscriptionId = stripeSubscription.id;
+    subscription.stripePriceId = priceId;
+    subscription.tier = tier;
+    subscription.status = 'active';
+    subscription.currentPeriodStart = new Date(stripeSubscription.current_period_start * 1000);
+    subscription.currentPeriodEnd = new Date(stripeSubscription.current_period_end * 1000);
+    subscription.cancelAtPeriodEnd = stripeSubscription.cancel_at_period_end;
+    await this.subscriptionRepository.save(subscription);
+
+    // Update user tier
+    await this.userService.updateTier(subscription.userId, tier);
+    this.logger.log(`Subscription created: user=${subscription.userId}, tier=${tier}`);
+  }
+
+  async handleSubscriptionUpdated(stripeSubscription: StripeSubscriptionData): Promise<void> {
+    this.logger.log(`Handling subscription updated: ${stripeSubscription.id}`);
+
+    const subscription = await this.getSubscriptionByStripeId(stripeSubscription.id);
+    if (!subscription) {
+      this.logger.warn(`No subscription found: ${stripeSubscription.id}`);
+      return;
+    }
+
+    const priceId = stripeSubscription.items.data[0]?.price.id;
+    const tier = getTierFromPriceId(priceId);
+
+    subscription.tier = tier;
+    subscription.status = this.mapStripeStatus(stripeSubscription.status);
+    subscription.currentPeriodStart = new Date(stripeSubscription.current_period_start * 1000);
+    subscription.currentPeriodEnd = new Date(stripeSubscription.current_period_end * 1000);
+    subscription.cancelAtPeriodEnd = stripeSubscription.cancel_at_period_end;
+    await this.subscriptionRepository.save(subscription);
+
+    // Update user tier if subscription is active
+    if (subscription.status === 'active') {
+      await this.userService.updateTier(subscription.userId, tier);
+    }
+
+    this.logger.log(`Subscription updated: user=${subscription.userId}, tier=${tier}, status=${subscription.status}`);
+  }
+
+  async handleSubscriptionDeleted(stripeSubscription: StripeSubscriptionData): Promise<void> {
+    this.logger.log(`Handling subscription deleted: ${stripeSubscription.id}`);
+
+    const subscription = await this.getSubscriptionByStripeId(stripeSubscription.id);
+    if (!subscription) {
+      this.logger.warn(`No subscription found for deletion: ${stripeSubscription.id}`);
+      return;
+    }
+
+    subscription.status = 'canceled';
+    subscription.canceledAt = new Date();
+    await this.subscriptionRepository.save(subscription);
+
+    // Downgrade user to free tier
+    await this.userService.updateTier(subscription.userId, UserTier.FREE);
+    this.logger.log(`Subscription deleted: user=${subscription.userId} downgraded to free`);
+  }
+
+  async handleInvoicePaymentSucceeded(invoice: StripeInvoiceData): Promise<void> {
+    if (!invoice.subscription) return;
+
+    this.logger.log(`Handling invoice payment succeeded: ${invoice.id}`);
+
+    const subscription = await this.getSubscriptionByStripeId(invoice.subscription as string);
+    if (subscription) {
+      // Reset monthly usage on successful payment (new billing period)
+      await this.userService.resetMonthlyUsage(subscription.userId);
+      this.logger.log(`Reset usage for user ${subscription.userId} after successful payment`);
+    }
+  }
+
+  async handleInvoicePaymentFailed(invoice: StripeInvoiceData): Promise<void> {
+    if (!invoice.subscription) return;
+
+    this.logger.warn(`Invoice payment failed: ${invoice.id}`);
+
+    const subscription = await this.getSubscriptionByStripeId(invoice.subscription as string);
+    if (subscription) {
+      subscription.status = 'past_due';
+      await this.subscriptionRepository.save(subscription);
+      this.logger.warn(`Subscription ${subscription.id} marked as past_due`);
+    }
+  }
+
+  private mapStripeStatus(status: string): 'active' | 'canceled' | 'past_due' | 'incomplete' | 'trialing' {
+    const statusMap: Record<string, 'active' | 'canceled' | 'past_due' | 'incomplete' | 'trialing'> = {
+      active: 'active',
+      canceled: 'canceled',
+      past_due: 'past_due',
+      incomplete: 'incomplete',
+      trialing: 'trialing',
+      incomplete_expired: 'canceled',
+      unpaid: 'past_due',
+      paused: 'canceled',
+    };
+    return statusMap[status] || 'active';
+  }
+}

--- a/packages/backend/src/subscription/tier-config.ts
+++ b/packages/backend/src/subscription/tier-config.ts
@@ -1,0 +1,76 @@
+export enum UserTier {
+  FREE = 'free',
+  PRO = 'pro',
+  ENTERPRISE = 'enterprise',
+}
+
+export interface TierLimits {
+  monthlyServerLimit: number;
+  privateRepos: boolean;
+  ciCd: boolean;
+  customDomains: boolean;
+  sla: boolean;
+  prioritySupport: boolean;
+  deploymentTypes: ('gist' | 'repo' | 'enterprise')[];
+}
+
+export const TIER_CONFIG: Record<UserTier, TierLimits> = {
+  [UserTier.FREE]: {
+    monthlyServerLimit: 5,
+    privateRepos: false,
+    ciCd: false,
+    customDomains: false,
+    sla: false,
+    prioritySupport: false,
+    deploymentTypes: ['gist'],
+  },
+  [UserTier.PRO]: {
+    monthlyServerLimit: Infinity,
+    privateRepos: true,
+    ciCd: true,
+    customDomains: false,
+    sla: false,
+    prioritySupport: true,
+    deploymentTypes: ['gist', 'repo'],
+  },
+  [UserTier.ENTERPRISE]: {
+    monthlyServerLimit: Infinity,
+    privateRepos: true,
+    ciCd: true,
+    customDomains: true,
+    sla: true,
+    prioritySupport: true,
+    deploymentTypes: ['gist', 'repo', 'enterprise'],
+  },
+};
+
+export const STRIPE_PRICES = {
+  PRO_MONTHLY: {
+    priceId: process.env.STRIPE_PRO_MONTHLY_PRICE_ID || 'price_pro_monthly',
+    amount: 2900, // $29.00
+  },
+  PRO_YEARLY: {
+    priceId: process.env.STRIPE_PRO_YEARLY_PRICE_ID || 'price_pro_yearly',
+    amount: 29000, // $290.00 (2 months free)
+  },
+  ENTERPRISE_MONTHLY: {
+    priceId: process.env.STRIPE_ENTERPRISE_MONTHLY_PRICE_ID || 'price_enterprise_monthly',
+    amount: 9900, // $99.00
+  },
+};
+
+export const TIER_DISPLAY_NAMES: Record<UserTier, string> = {
+  [UserTier.FREE]: 'Free',
+  [UserTier.PRO]: 'Pro',
+  [UserTier.ENTERPRISE]: 'Enterprise',
+};
+
+export function getTierFromPriceId(priceId: string): UserTier {
+  if (priceId === STRIPE_PRICES.PRO_MONTHLY.priceId || priceId === STRIPE_PRICES.PRO_YEARLY.priceId) {
+    return UserTier.PRO;
+  }
+  if (priceId === STRIPE_PRICES.ENTERPRISE_MONTHLY.priceId) {
+    return UserTier.ENTERPRISE;
+  }
+  return UserTier.FREE;
+}

--- a/packages/backend/src/user/account.controller.ts
+++ b/packages/backend/src/user/account.controller.ts
@@ -1,0 +1,104 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Delete,
+  Body,
+  HttpCode,
+  HttpStatus,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { UserService } from './user.service';
+import { UpdateAccountDto, AccountDto, UserProfileDto } from './dto/user.dto';
+import { User } from '../database/entities/user.entity';
+
+// TODO: Replace with proper auth guard once authentication is implemented
+function getCurrentUser(req: Request): User | null {
+  // For now, get user from a header or session
+  // This will be replaced with proper JWT/session auth
+  return (req as any).user || null;
+}
+
+@Controller('api/account')
+export class AccountController {
+  constructor(private readonly userService: UserService) {}
+
+  @Get()
+  async getAccount(@Req() req: Request): Promise<AccountDto> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      tier: user.tier,
+      isEmailVerified: user.isEmailVerified,
+      createdAt: user.createdAt,
+    };
+  }
+
+  @Get('profile')
+  async getProfile(@Req() req: Request): Promise<UserProfileDto> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      githubUsername: user.githubUsername,
+      tier: user.tier,
+      isEmailVerified: user.isEmailVerified,
+      lastLoginAt: user.lastLoginAt,
+      createdAt: user.createdAt,
+    };
+  }
+
+  @Patch()
+  @HttpCode(HttpStatus.OK)
+  async updateAccount(
+    @Req() req: Request,
+    @Body() dto: UpdateAccountDto,
+  ): Promise<AccountDto> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    const updated = await this.userService.updateUser(user.id, {
+      firstName: dto.firstName,
+      lastName: dto.lastName,
+    });
+
+    return {
+      id: updated.id,
+      email: updated.email,
+      firstName: updated.firstName,
+      lastName: updated.lastName,
+      tier: updated.tier,
+      isEmailVerified: updated.isEmailVerified,
+      createdAt: updated.createdAt,
+    };
+  }
+
+  @Delete()
+  @HttpCode(HttpStatus.OK)
+  async deleteAccount(@Req() req: Request): Promise<{ success: boolean }> {
+    const user = getCurrentUser(req);
+    if (!user) {
+      throw new UnauthorizedException('Not authenticated');
+    }
+
+    await this.userService.deleteUser(user.id);
+    return { success: true };
+  }
+}

--- a/packages/backend/src/user/dto/user.dto.ts
+++ b/packages/backend/src/user/dto/user.dto.ts
@@ -1,0 +1,81 @@
+import { IsEmail, IsString, IsOptional, MinLength, IsBoolean } from 'class-validator';
+
+export class CreateUserDto {
+  @IsEmail()
+  email: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(8)
+  password?: string;
+
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @IsOptional()
+  @IsString()
+  githubId?: string;
+
+  @IsOptional()
+  @IsString()
+  githubUsername?: string;
+
+  @IsOptional()
+  @IsString()
+  googleId?: string;
+}
+
+export class UpdateUserDto {
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @IsOptional()
+  @IsString()
+  githubUsername?: string;
+}
+
+export class UpdateAccountDto {
+  @IsOptional()
+  @IsString()
+  firstName?: string;
+
+  @IsOptional()
+  @IsString()
+  lastName?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  emailNotifications?: boolean;
+}
+
+export interface AccountDto {
+  id: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  tier: string;
+  isEmailVerified: boolean;
+  createdAt: Date;
+}
+
+export interface UserProfileDto {
+  id: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  githubUsername?: string;
+  tier: string;
+  isEmailVerified: boolean;
+  lastLoginAt?: Date;
+  createdAt: Date;
+}

--- a/packages/backend/src/user/user.module.ts
+++ b/packages/backend/src/user/user.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '../database/entities/user.entity';
+import { UsageRecord } from '../database/entities/usage.entity';
+import { UserService } from './user.service';
+import { AccountController } from './account.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User, UsageRecord]),
+  ],
+  controllers: [AccountController],
+  providers: [UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/packages/backend/src/user/user.service.ts
+++ b/packages/backend/src/user/user.service.ts
@@ -1,0 +1,223 @@
+import { Injectable, Logger, NotFoundException, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { User } from '../database/entities/user.entity';
+import { UsageRecord } from '../database/entities/usage.entity';
+import { UserTier, TIER_CONFIG } from '../subscription/tier-config';
+import { CreateUserDto, UpdateUserDto } from './dto/user.dto';
+
+@Injectable()
+export class UserService {
+  private readonly logger = new Logger(UserService.name);
+  private readonly SALT_ROUNDS = 10;
+
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(UsageRecord)
+    private readonly usageRepository: Repository<UsageRecord>,
+  ) {}
+
+  async findById(id: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { id } });
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { email: email.toLowerCase() } });
+  }
+
+  async findByGithubId(githubId: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { githubId } });
+  }
+
+  async findByGoogleId(googleId: string): Promise<User | null> {
+    return this.userRepository.findOne({ where: { googleId } });
+  }
+
+  async createUser(dto: CreateUserDto): Promise<User> {
+    const email = dto.email.toLowerCase();
+    const existing = await this.findByEmail(email);
+    if (existing) {
+      throw new ConflictException('User with this email already exists');
+    }
+
+    let passwordHash: string | undefined;
+    if (dto.password) {
+      passwordHash = await bcrypt.hash(dto.password, this.SALT_ROUNDS);
+    }
+
+    const user = this.userRepository.create({
+      email,
+      passwordHash,
+      firstName: dto.firstName,
+      lastName: dto.lastName,
+      githubId: dto.githubId,
+      githubUsername: dto.githubUsername,
+      googleId: dto.googleId,
+      tier: UserTier.FREE,
+    });
+
+    const savedUser = await this.userRepository.save(user);
+    this.logger.log(`Created user: ${savedUser.id} (${savedUser.email})`);
+
+    // Create initial usage record
+    await this.createUsageRecord(savedUser.id);
+
+    return savedUser;
+  }
+
+  async updateUser(userId: string, dto: UpdateUserDto): Promise<User> {
+    const user = await this.findById(userId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    if (dto.firstName !== undefined) user.firstName = dto.firstName;
+    if (dto.lastName !== undefined) user.lastName = dto.lastName;
+    if (dto.githubUsername !== undefined) user.githubUsername = dto.githubUsername;
+
+    return this.userRepository.save(user);
+  }
+
+  async deleteUser(userId: string): Promise<void> {
+    const user = await this.findById(userId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    await this.userRepository.remove(user);
+    this.logger.log(`Deleted user: ${userId}`);
+  }
+
+  async validatePassword(user: User, password: string): Promise<boolean> {
+    if (!user.passwordHash) {
+      return false;
+    }
+    return bcrypt.compare(password, user.passwordHash);
+  }
+
+  async updateLastLogin(userId: string): Promise<void> {
+    await this.userRepository.update(userId, { lastLoginAt: new Date() });
+  }
+
+  async updateTier(userId: string, tier: UserTier): Promise<User> {
+    const user = await this.findById(userId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const previousTier = user.tier;
+    user.tier = tier;
+    const savedUser = await this.userRepository.save(user);
+
+    // Update usage limits based on tier
+    const usage = await this.getCurrentUsage(userId);
+    const tierConfig = TIER_CONFIG[tier];
+    usage.monthlyLimit = tierConfig.monthlyServerLimit === Infinity ? 999999 : tierConfig.monthlyServerLimit;
+    await this.usageRepository.save(usage);
+
+    this.logger.log(`Updated user ${userId} tier: ${previousTier} -> ${tier}`);
+    return savedUser;
+  }
+
+  async getCurrentUsage(userId: string): Promise<UsageRecord> {
+    const now = new Date();
+    let usage = await this.usageRepository.findOne({
+      where: { userId },
+      order: { periodEnd: 'DESC' },
+    });
+
+    // If no usage record or current period ended, create new one
+    if (!usage || usage.periodEnd < now) {
+      usage = await this.createUsageRecord(userId);
+    }
+
+    return usage;
+  }
+
+  async incrementUsage(userId: string): Promise<UsageRecord> {
+    const usage = await this.getCurrentUsage(userId);
+    usage.serversDeployedThisMonth += 1;
+    const saved = await this.usageRepository.save(usage);
+    this.logger.log(`Incremented usage for user ${userId}: ${saved.serversDeployedThisMonth}/${saved.monthlyLimit}`);
+    return saved;
+  }
+
+  async checkCanDeploy(userId: string): Promise<{ allowed: boolean; reason?: string; usage?: UsageRecord }> {
+    const user = await this.findById(userId);
+    if (!user) {
+      return { allowed: false, reason: 'User not found' };
+    }
+
+    const tierConfig = TIER_CONFIG[user.tier as UserTier];
+    const usage = await this.getCurrentUsage(userId);
+
+    // Pro and Enterprise have unlimited deployments
+    if (tierConfig.monthlyServerLimit === Infinity) {
+      return { allowed: true, usage };
+    }
+
+    if (usage.serversDeployedThisMonth >= tierConfig.monthlyServerLimit) {
+      return {
+        allowed: false,
+        reason: `You have reached your monthly limit of ${tierConfig.monthlyServerLimit} servers. Upgrade to Pro for unlimited deployments.`,
+        usage,
+      };
+    }
+
+    return { allowed: true, usage };
+  }
+
+  async resetMonthlyUsage(userId: string): Promise<void> {
+    this.logger.log(`Resetting monthly usage for user ${userId}`);
+    await this.createUsageRecord(userId);
+  }
+
+  async getUsageStats(userId: string): Promise<{
+    serversDeployedThisMonth: number;
+    monthlyLimit: number;
+    periodStart: Date;
+    periodEnd: Date;
+    percentUsed: number;
+    remainingDeployments: number;
+  }> {
+    const usage = await this.getCurrentUsage(userId);
+    const percentUsed = usage.monthlyLimit === 999999
+      ? 0
+      : Math.round((usage.serversDeployedThisMonth / usage.monthlyLimit) * 100);
+    const remainingDeployments = usage.monthlyLimit === 999999
+      ? 999999
+      : Math.max(0, usage.monthlyLimit - usage.serversDeployedThisMonth);
+
+    return {
+      serversDeployedThisMonth: usage.serversDeployedThisMonth,
+      monthlyLimit: usage.monthlyLimit,
+      periodStart: usage.periodStart,
+      periodEnd: usage.periodEnd,
+      percentUsed,
+      remainingDeployments,
+    };
+  }
+
+  private async createUsageRecord(userId: string): Promise<UsageRecord> {
+    const user = await this.findById(userId);
+    const tierConfig = TIER_CONFIG[(user?.tier as UserTier) || UserTier.FREE];
+
+    const now = new Date();
+    const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59, 999);
+
+    const usage = this.usageRepository.create({
+      userId,
+      serversDeployedThisMonth: 0,
+      monthlyLimit: tierConfig.monthlyServerLimit === Infinity ? 999999 : tierConfig.monthlyServerLimit,
+      periodStart,
+      periodEnd,
+    });
+
+    const saved = await this.usageRepository.save(usage);
+    this.logger.log(`Created usage record for user ${userId}: limit=${saved.monthlyLimit}`);
+    return saved;
+  }
+}

--- a/packages/frontend/src/app/core/services/subscription.service.ts
+++ b/packages/frontend/src/app/core/services/subscription.service.ts
@@ -1,0 +1,165 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, BehaviorSubject, tap, catchError, of } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+export interface TierLimits {
+  monthlyServerLimit: number;
+  privateRepos: boolean;
+  ciCd: boolean;
+  customDomains: boolean;
+  sla: boolean;
+  prioritySupport: boolean;
+}
+
+export interface TierInfo {
+  currentTier: 'free' | 'pro' | 'enterprise';
+  limits: TierLimits;
+  usage: {
+    serversDeployed: number;
+    limit: number;
+    periodEnd: string;
+  };
+  canUpgrade: boolean;
+}
+
+export interface SubscriptionInfo {
+  tier: 'free' | 'pro' | 'enterprise';
+  status: 'active' | 'canceled' | 'past_due' | 'incomplete' | 'trialing';
+  currentPeriodStart?: string;
+  currentPeriodEnd?: string;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface UsageInfo {
+  serversDeployedThisMonth: number;
+  monthlyLimit: number;
+  periodStart: string;
+  periodEnd: string;
+  percentUsed: number;
+  remainingDeployments: number;
+}
+
+export interface CheckoutSession {
+  sessionId: string;
+  url: string;
+}
+
+export interface PortalSession {
+  url: string;
+}
+
+export interface DeploymentLimitError {
+  code: 'LIMIT_EXCEEDED' | 'TIER_RESTRICTION' | 'USER_NOT_FOUND';
+  message: string;
+  currentUsage?: number;
+  limit?: number;
+  currentTier?: string;
+  requiredTier?: string;
+  upgradeUrl: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SubscriptionService {
+  private readonly baseUrl = `${environment.apiUrl}/api/subscription`;
+
+  private tierInfoSubject = new BehaviorSubject<TierInfo | null>(null);
+  private subscriptionSubject = new BehaviorSubject<SubscriptionInfo | null>(null);
+  private usageSubject = new BehaviorSubject<UsageInfo | null>(null);
+
+  public tierInfo$ = this.tierInfoSubject.asObservable();
+  public subscription$ = this.subscriptionSubject.asObservable();
+  public usage$ = this.usageSubject.asObservable();
+
+  constructor(private http: HttpClient) {}
+
+  getSubscription(): Observable<SubscriptionInfo> {
+    return this.http.get<SubscriptionInfo>(this.baseUrl).pipe(
+      tap(subscription => this.subscriptionSubject.next(subscription)),
+      catchError(error => {
+        console.error('Failed to get subscription:', error);
+        return of({
+          tier: 'free' as const,
+          status: 'active' as const,
+          cancelAtPeriodEnd: false
+        });
+      })
+    );
+  }
+
+  getTierInfo(): Observable<TierInfo> {
+    return this.http.get<TierInfo>(`${this.baseUrl}/tier`).pipe(
+      tap(tierInfo => this.tierInfoSubject.next(tierInfo)),
+      catchError(error => {
+        console.error('Failed to get tier info:', error);
+        return of({
+          currentTier: 'free' as const,
+          limits: {
+            monthlyServerLimit: 5,
+            privateRepos: false,
+            ciCd: false,
+            customDomains: false,
+            sla: false,
+            prioritySupport: false
+          },
+          usage: {
+            serversDeployed: 0,
+            limit: 5,
+            periodEnd: new Date().toISOString()
+          },
+          canUpgrade: true
+        });
+      })
+    );
+  }
+
+  getUsage(): Observable<UsageInfo> {
+    return this.http.get<UsageInfo>(`${this.baseUrl}/usage`).pipe(
+      tap(usage => this.usageSubject.next(usage)),
+      catchError(error => {
+        console.error('Failed to get usage:', error);
+        return of({
+          serversDeployedThisMonth: 0,
+          monthlyLimit: 5,
+          periodStart: new Date().toISOString(),
+          periodEnd: new Date().toISOString(),
+          percentUsed: 0,
+          remainingDeployments: 5
+        });
+      })
+    );
+  }
+
+  createCheckout(tier: 'pro' | 'enterprise', interval: 'monthly' | 'yearly' = 'monthly'): Observable<CheckoutSession> {
+    return this.http.post<CheckoutSession>(`${this.baseUrl}/checkout`, { tier, interval });
+  }
+
+  createPortal(): Observable<PortalSession> {
+    return this.http.post<PortalSession>(`${this.baseUrl}/portal`, {});
+  }
+
+  refreshAll(): void {
+    this.getSubscription().subscribe();
+    this.getTierInfo().subscribe();
+    this.getUsage().subscribe();
+  }
+
+  isDeploymentLimitError(error: any): error is { error: DeploymentLimitError } {
+    return error?.error?.code && ['LIMIT_EXCEEDED', 'TIER_RESTRICTION', 'USER_NOT_FOUND'].includes(error.error.code);
+  }
+
+  getTierDisplayName(tier: string): string {
+    switch (tier) {
+      case 'free': return 'Free';
+      case 'pro': return 'Pro';
+      case 'enterprise': return 'Enterprise';
+      default: return tier;
+    }
+  }
+
+  isUnlimited(limit: number): boolean {
+    return limit >= 999999;
+  }
+}

--- a/packages/frontend/src/app/features/account/account.component.html
+++ b/packages/frontend/src/app/features/account/account.component.html
@@ -163,6 +163,118 @@
       </div>
     </div>
 
+    <!-- Subscription & Tier Section -->
+    <div class="settings-section" *ngIf="tierInfo$ | async as tierInfo">
+      <div class="section-header">
+        <div class="section-icon">
+          <mat-icon>workspace_premium</mat-icon>
+        </div>
+        <div class="section-title">
+          <h2>Subscription</h2>
+          <p>Manage your plan and billing</p>
+        </div>
+      </div>
+
+      <div class="section-content">
+        <!-- Current Plan Display -->
+        <div class="current-plan-card">
+          <div class="plan-header">
+            <span class="plan-badge" [ngClass]="tierInfo.currentTier">
+              {{ getTierDisplayName(tierInfo.currentTier) }} Plan
+            </span>
+            <span class="plan-status" *ngIf="(subscription$ | async) as sub">
+              {{ sub.status === 'active' ? 'Active' : (sub.status | titlecase) }}
+            </span>
+          </div>
+
+          <!-- Usage Progress (Free tier only) -->
+          <div class="usage-progress" *ngIf="tierInfo.currentTier === 'free'">
+            <div class="usage-header">
+              <span>Servers deployed this month</span>
+              <span class="usage-count">
+                {{ tierInfo.usage.serversDeployed }} / {{ tierInfo.usage.limit }}
+              </span>
+            </div>
+            <div class="progress-bar-container">
+              <div
+                class="progress-bar-fill"
+                [style.width.%]="(tierInfo.usage.serversDeployed / tierInfo.usage.limit) * 100"
+                [class.warning]="tierInfo.usage.serversDeployed >= tierInfo.usage.limit * 0.8"
+                [class.critical]="tierInfo.usage.serversDeployed >= tierInfo.usage.limit">
+              </div>
+            </div>
+            <div class="usage-reset-info">
+              Resets on {{ tierInfo.usage.periodEnd | date:'mediumDate' }}
+            </div>
+          </div>
+
+          <!-- Plan Features -->
+          <div class="plan-features">
+            <div class="feature-item" [class.enabled]="true">
+              <mat-icon>check_circle</mat-icon>
+              <span>{{ isUnlimited(tierInfo.limits.monthlyServerLimit) ? 'Unlimited' : tierInfo.limits.monthlyServerLimit }} servers/month</span>
+            </div>
+            <div class="feature-item" [class.enabled]="tierInfo.limits.privateRepos">
+              <mat-icon>{{ tierInfo.limits.privateRepos ? 'check_circle' : 'cancel' }}</mat-icon>
+              <span>Private repositories</span>
+            </div>
+            <div class="feature-item" [class.enabled]="tierInfo.limits.ciCd">
+              <mat-icon>{{ tierInfo.limits.ciCd ? 'check_circle' : 'cancel' }}</mat-icon>
+              <span>CI/CD pipelines</span>
+            </div>
+            <div class="feature-item" [class.enabled]="tierInfo.limits.customDomains">
+              <mat-icon>{{ tierInfo.limits.customDomains ? 'check_circle' : 'cancel' }}</mat-icon>
+              <span>Custom domains</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Upgrade CTA (Free tier) -->
+        <div class="upgrade-section" *ngIf="tierInfo.currentTier === 'free'">
+          <div class="upgrade-card">
+            <div class="upgrade-header">
+              <mat-icon>rocket_launch</mat-icon>
+              <h3>Upgrade to Pro</h3>
+            </div>
+            <p class="upgrade-description">
+              Unlock unlimited MCP server generation, private repositories, and CI/CD automation.
+            </p>
+            <ul class="upgrade-benefits">
+              <li><mat-icon>check</mat-icon> Unlimited MCP servers</li>
+              <li><mat-icon>check</mat-icon> Private GitHub repositories</li>
+              <li><mat-icon>check</mat-icon> Automated CI/CD pipelines</li>
+              <li><mat-icon>check</mat-icon> Priority support</li>
+            </ul>
+            <div class="upgrade-price">
+              <span class="price">$29</span>
+              <span class="period">/month</span>
+            </div>
+            <button
+              class="action-button primary upgrade-button"
+              (click)="upgradeToPro()"
+              [disabled]="isUpgrading">
+              <mat-icon *ngIf="!isUpgrading">upgrade</mat-icon>
+              <mat-icon *ngIf="isUpgrading" class="spinning">sync</mat-icon>
+              <span>{{ isUpgrading ? 'Loading...' : 'Upgrade Now' }}</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- Manage Subscription (Paid tiers) -->
+        <div class="manage-subscription" *ngIf="tierInfo.currentTier !== 'free'">
+          <button
+            class="action-button secondary"
+            (click)="manageSubscription()">
+            <mat-icon>settings</mat-icon>
+            <span>Manage Subscription</span>
+          </button>
+          <p class="billing-note" *ngIf="(subscription$ | async)?.currentPeriodEnd as periodEnd">
+            Next billing date: {{ periodEnd | date:'mediumDate' }}
+          </p>
+        </div>
+      </div>
+    </div>
+
     <!-- Preferences Section -->
     <div class="settings-section">
       <div class="section-header">

--- a/packages/frontend/src/app/features/account/account.component.scss
+++ b/packages/frontend/src/app/features/account/account.component.scss
@@ -653,3 +653,238 @@
     }
   }
 }
+
+// Subscription Section Styles
+.current-plan-card {
+  background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  padding: 24px;
+  margin-bottom: 24px;
+
+  .plan-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 20px;
+
+    .plan-badge {
+      padding: 6px 16px;
+      border-radius: 20px;
+      font-weight: 600;
+      font-size: 14px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+
+      &.free {
+        background-color: #e8e8e8;
+        color: #555;
+      }
+
+      &.pro {
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+      }
+
+      &.enterprise {
+        background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+        color: white;
+      }
+    }
+
+    .plan-status {
+      font-size: 13px;
+      color: #22c55e;
+      font-weight: 500;
+    }
+  }
+}
+
+.usage-progress {
+  margin-bottom: 20px;
+
+  .usage-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+    font-size: 14px;
+    color: #555;
+
+    .usage-count {
+      font-weight: 600;
+      color: #1f1f1f;
+    }
+  }
+
+  .progress-bar-container {
+    height: 8px;
+    background-color: #e5e5e5;
+    border-radius: 4px;
+    overflow: hidden;
+
+    .progress-bar-fill {
+      height: 100%;
+      background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+      border-radius: 4px;
+      transition: width 0.3s ease;
+
+      &.warning {
+        background: linear-gradient(90deg, #f59e0b 0%, #d97706 100%);
+      }
+
+      &.critical {
+        background: linear-gradient(90deg, #ef4444 0%, #dc2626 100%);
+      }
+    }
+  }
+
+  .usage-reset-info {
+    margin-top: 8px;
+    font-size: 12px;
+    color: #888;
+  }
+}
+
+.plan-features {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+
+  .feature-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 14px;
+    color: #888;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      color: #ccc;
+    }
+
+    &.enabled {
+      color: #1f1f1f;
+
+      mat-icon {
+        color: #22c55e;
+      }
+    }
+  }
+}
+
+.upgrade-section {
+  .upgrade-card {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border-radius: 12px;
+    padding: 24px;
+    color: white;
+
+    .upgrade-header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 16px;
+
+      mat-icon {
+        font-size: 28px;
+        width: 28px;
+        height: 28px;
+      }
+
+      h3 {
+        margin: 0;
+        font-size: 20px;
+        font-weight: 600;
+      }
+    }
+
+    .upgrade-description {
+      margin: 0 0 16px 0;
+      opacity: 0.9;
+      line-height: 1.5;
+    }
+
+    .upgrade-benefits {
+      list-style: none;
+      padding: 0;
+      margin: 0 0 20px 0;
+
+      li {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 8px;
+        font-size: 14px;
+
+        mat-icon {
+          font-size: 16px;
+          width: 16px;
+          height: 16px;
+        }
+      }
+    }
+
+    .upgrade-price {
+      margin-bottom: 20px;
+
+      .price {
+        font-size: 36px;
+        font-weight: 700;
+      }
+
+      .period {
+        font-size: 16px;
+        opacity: 0.8;
+      }
+    }
+
+    .upgrade-button {
+      background-color: white;
+      color: #667eea;
+      width: 100%;
+      padding: 14px 24px;
+
+      &:hover {
+        background-color: #f8f9fa;
+      }
+
+      &:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+
+      .spinning {
+        animation: spin 1s linear infinite;
+      }
+    }
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.manage-subscription {
+  text-align: center;
+
+  .billing-note {
+    margin-top: 12px;
+    font-size: 13px;
+    color: #888;
+  }
+}
+
+// Responsive adjustments for subscription section
+@media (max-width: 768px) {
+  .plan-features {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Implements 3-tier deployment system (Free/Pro/Enterprise) as specified in #15
- Adds Stripe subscription management with checkout and billing portal
- Creates tier-based deployment routing with usage limits enforcement

## Changes

### Database
- New entities: `User`, `Subscription`, `UsageRecord`
- Migration creates `users`, `subscriptions`, `usage_records` tables
- Added `userId`/`userTier` fields to Deployment and Conversation entities

### Backend Services
- **UserService**: User CRUD, usage tracking, limit checking
- **StripeService**: Stripe API wrapper for payments
- **SubscriptionService**: Subscription lifecycle, webhook handlers
- **DeploymentRouterService**: Tier-based deployment routing

### API Endpoints
| Endpoint | Description |
|----------|-------------|
| `GET /api/subscription` | Get current subscription |
| `GET /api/subscription/tier` | Get tier info + usage |
| `GET /api/subscription/usage` | Get usage statistics |
| `POST /api/subscription/checkout` | Create Stripe checkout session |
| `POST /api/subscription/portal` | Create Stripe billing portal |
| `POST /api/webhooks/stripe` | Handle Stripe webhook events |

### Frontend
- `SubscriptionService` for tier management API calls
- Updated Account page with subscription display, usage progress bar, upgrade CTA

## Tier Features

| Feature | Free | Pro ($29/mo) | Enterprise |
|---------|------|--------------|------------|
| Servers/month | 5 | Unlimited | Unlimited |
| Private repos | ❌ | ✅ | ✅ |
| CI/CD | ❌ | ✅ | ✅ |
| Custom domains | ❌ | ❌ | ✅ |
| Deployment types | Gist | Gist, Repo | All |

## Test Plan
- [ ] Free user can deploy up to 5 servers
- [ ] Free user blocked at limit with upgrade prompt
- [ ] Stripe checkout flow works (requires test keys)
- [ ] Webhook updates user tier correctly
- [ ] Pro user has unlimited deployments
- [ ] Billing portal accessible for paid users
- [ ] Usage resets on subscription renewal

## Environment Variables Required
```env
STRIPE_SECRET_KEY=sk_test_...
STRIPE_WEBHOOK_SECRET=whsec_...
STRIPE_PRO_MONTHLY_PRICE_ID=price_...
STRIPE_PRO_YEARLY_PRICE_ID=price_...
STRIPE_ENTERPRISE_MONTHLY_PRICE_ID=price_...
```

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)