### PR TITLE
feat(hosting): Add K8s namespace and base resources (#27)

### DIFF
--- a/mcp-server-deployments/base/limit-range.yaml
+++ b/mcp-server-deployments/base/limit-range.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mcp-servers-limits
+  namespace: mcp-servers
+spec:
+  limits:
+    - default:
+        cpu: 500m
+        memory: 256Mi
+      defaultRequest:
+        cpu: 100m
+        memory: 128Mi
+      type: Container

--- a/mcp-server-deployments/base/namespace.yaml
+++ b/mcp-server-deployments/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp-servers
+  labels:
+    app.kubernetes.io/name: mcp-servers
+    app.kubernetes.io/part-of: mcp-everything

--- a/mcp-server-deployments/base/network-policy.yaml
+++ b/mcp-server-deployments/base/network-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mcp-servers-policy
+  namespace: mcp-servers
+spec:
+  podSelector:
+    matchLabels:
+      app: mcp-server
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+  egress:
+    - {} # Allow all egress (MCP servers may call external APIs)

--- a/mcp-server-deployments/base/resource-quota.yaml
+++ b/mcp-server-deployments/base/resource-quota.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: mcp-servers-quota
+  namespace: mcp-servers
+spec:
+  hard:
+    requests.cpu: "10"
+    requests.memory: 10Gi
+    limits.cpu: "20"
+    limits.memory: 20Gi
+    pods: "100"


### PR DESCRIPTION
## Summary
- Set up foundational Kubernetes resources for hosting MCP servers
- Creates `mcp-servers` namespace with standard K8s labels
- Adds ResourceQuota to prevent runaway resource usage (10/20 CPU, 10Gi/20Gi memory, 100 pods)
- Adds LimitRange for default container limits (500m CPU, 256Mi memory)
- Adds NetworkPolicy to isolate MCP servers (ingress from nginx only, all egress allowed)

## Files Created
- `mcp-server-deployments/base/namespace.yaml`
- `mcp-server-deployments/base/resource-quota.yaml`
- `mcp-server-deployments/base/limit-range.yaml`
- `mcp-server-deployments/base/network-policy.yaml`

## Test plan
- [ ] Verify YAML syntax is valid (`kubectl apply --dry-run=client -f`)
- [ ] Review resource limits match expected values from issue

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)