### PR TITLE
feat(hosting): GitOps Repository and ArgoCD Setup (#29)

### DIFF
--- a/docs/HOSTING_ARCHITECTURE.md
+++ b/docs/HOSTING_ARCHITECTURE.md
@@ -4,6 +4,19 @@
 
 This document describes the architecture for dynamically hosting generated MCP servers on a self-managed Kubernetes cluster.
 
+## GitOps Repository
+
+The GitOps manifests are managed in a dedicated repository:
+
+**Repository**: [mcp-server-deployments](https://github.com/4eyedengineer/mcp-server-deployments)
+
+This repository contains:
+- **base/**: Kustomize base resources (namespace, quotas, limits, network policies)
+- **argocd/**: ArgoCD ApplicationSet for dynamic server discovery
+- **servers/**: Auto-generated per-server K8s manifests
+
+See the [mcp-server-deployments README](https://github.com/4eyedengineer/mcp-server-deployments#readme) for setup instructions.
+
 ## High-Level Flow
 
 ```


### PR DESCRIPTION
## Summary

- Created new GitHub repository [`mcp-server-deployments`](https://github.com/4eyedengineer/mcp-server-deployments) for GitOps-based K8s deployments
- Updated `docs/HOSTING_ARCHITECTURE.md` to link to the new repository

## GitOps Repository Contents

The [`mcp-server-deployments`](https://github.com/4eyedengineer/mcp-server-deployments) repository includes:

### Base Resources (`base/`)
- `namespace.yaml` - mcp-servers namespace with restricted pod security
- `resource-quota.yaml` - Namespace limits (20 cores, 40Gi RAM, 100 pods)
- `limit-range.yaml` - Per-pod defaults (100m/500m CPU, 128Mi/256Mi memory)
- `network-policy.yaml` - Ingress from nginx-ingress only, HTTPS egress only
- `kustomization.yaml` - Kustomize configuration

### ArgoCD Configuration (`argocd/`)
- `applicationset.yaml` - Dynamic server discovery via Git directory generator
- `mcp-servers-base.yaml` - Application for base resources

### Servers Placeholder (`servers/`)
- `.gitkeep` - Placeholder for auto-generated server manifests

## Test Plan

- [x] GitOps repo created and pushed: https://github.com/4eyedengineer/mcp-server-deployments
- [x] Base resources in repo (namespace, quota, limits, network policy)
- [x] ArgoCD ApplicationSet configured
- [x] Base Application configured
- [x] README with setup instructions
- [ ] Test on K8s cluster with ArgoCD (manual verification)

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)