### PR TITLE
feat(db): Add hosted_servers table and HostedServer entity

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -14,7 +14,7 @@ import { DeploymentModule } from './deployment/deployment.module';
 import { ValidationModule } from './validation/validation.module';
 import { UserModule } from './user/user.module';
 import { SubscriptionModule } from './subscription/subscription.module';
-import { Conversation, ConversationMemory, Deployment, User, Subscription, UsageRecord } from './database/entities';
+import { Conversation, ConversationMemory, Deployment, User, Subscription, UsageRecord, HostedServer } from './database/entities';
 
 // Basic DTO for generate endpoint
 export class GenerateServerDto {
@@ -287,7 +287,7 @@ main().catch((error) => {
       username: process.env.DATABASE_USER || 'postgres',
       password: process.env.DATABASE_PASSWORD || 'postgres',
       database: process.env.DATABASE_NAME || 'mcp_everything',
-      entities: [Conversation, ConversationMemory, Deployment, User, Subscription, UsageRecord],
+      entities: [Conversation, ConversationMemory, Deployment, User, Subscription, UsageRecord, HostedServer],
       synchronize: process.env.NODE_ENV !== 'production', // Auto-sync in development
       logging: process.env.NODE_ENV === 'development',
     }),

--- a/packages/backend/src/database/entities/hosted-server.entity.ts
+++ b/packages/backend/src/database/entities/hosted-server.entity.ts
@@ -1,0 +1,110 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Conversation } from './conversation.entity';
+
+export type HostedServerStatus =
+  | 'pending'
+  | 'building'
+  | 'pushing'
+  | 'deploying'
+  | 'running'
+  | 'stopped'
+  | 'failed'
+  | 'deleted';
+
+@Entity('hosted_servers')
+export class HostedServer {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'conversation_id', type: 'uuid', nullable: true })
+  conversationId: string;
+
+  @ManyToOne(() => Conversation, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'conversation_id' })
+  conversation: Conversation;
+
+  @Column({ name: 'user_id', type: 'uuid', nullable: true })
+  userId: string;
+
+  // Server identification
+  @Column({ name: 'server_name', length: 100 })
+  serverName: string;
+
+  @Index()
+  @Column({ name: 'server_id', length: 50, unique: true })
+  serverId: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  // Container info
+  @Column({ name: 'docker_image', length: 255 })
+  dockerImage: string;
+
+  @Column({ name: 'image_tag', length: 100, default: 'latest' })
+  imageTag: string;
+
+  // K8s info
+  @Column({ name: 'k8s_namespace', length: 100, default: 'mcp-servers' })
+  k8sNamespace: string;
+
+  @Column({ name: 'k8s_deployment_name', length: 100, nullable: true })
+  k8sDeploymentName: string;
+
+  // Endpoint
+  @Column({ name: 'endpoint_url', type: 'text' })
+  endpointUrl: string;
+
+  // Status
+  @Index()
+  @Column({ length: 20, default: 'pending' })
+  status: HostedServerStatus;
+
+  @Column({ name: 'status_message', type: 'text', nullable: true })
+  statusMessage: string;
+
+  @Column({ name: 'last_status_change', type: 'timestamp', default: () => 'NOW()' })
+  lastStatusChange: Date;
+
+  // Usage
+  @Column({ name: 'request_count', default: 0 })
+  requestCount: number;
+
+  @Column({ name: 'last_request_at', type: 'timestamp', nullable: true })
+  lastRequestAt: Date;
+
+  // Lifecycle
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+
+  @Column({ name: 'deployed_at', type: 'timestamp', nullable: true })
+  deployedAt: Date;
+
+  @Column({ name: 'stopped_at', type: 'timestamp', nullable: true })
+  stoppedAt: Date;
+
+  @Column({ name: 'deleted_at', type: 'timestamp', nullable: true })
+  deletedAt: Date;
+
+  // Metadata
+  @Column({ type: 'jsonb', nullable: true })
+  tools: Array<{ name: string; description: string; inputSchema: any }>;
+
+  @Column({ name: 'env_var_names', type: 'jsonb', nullable: true })
+  envVarNames: string[];
+
+  @Column({ type: 'jsonb', nullable: true })
+  config: Record<string, any>;
+}

--- a/packages/backend/src/database/entities/index.ts
+++ b/packages/backend/src/database/entities/index.ts
@@ -5,3 +5,4 @@ export { Deployment } from './deployment.entity';
 export { User } from './user.entity';
 export { Subscription } from './subscription.entity';
 export { UsageRecord } from './usage.entity';
+export { HostedServer } from './hosted-server.entity';

--- a/packages/backend/src/database/migrations/1733200000000-CreateHostedServersTable.ts
+++ b/packages/backend/src/database/migrations/1733200000000-CreateHostedServersTable.ts
@@ -1,0 +1,64 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateHostedServersTable1733200000000 implements MigrationInterface {
+  name = 'CreateHostedServersTable1733200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE hosted_servers (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        conversation_id UUID REFERENCES conversations(id) ON DELETE SET NULL,
+        user_id UUID,  -- For future auth integration
+
+        -- Server identification
+        server_name VARCHAR(100) NOT NULL,
+        server_id VARCHAR(50) UNIQUE NOT NULL,  -- URL-safe ID: stripe-abc123
+        description TEXT,
+
+        -- Container info
+        docker_image VARCHAR(255) NOT NULL,
+        image_tag VARCHAR(100) DEFAULT 'latest',
+
+        -- K8s info
+        k8s_namespace VARCHAR(100) DEFAULT 'mcp-servers',
+        k8s_deployment_name VARCHAR(100),
+
+        -- Endpoint
+        endpoint_url TEXT NOT NULL,
+
+        -- Status tracking
+        status VARCHAR(20) DEFAULT 'pending'
+          CHECK (status IN ('pending', 'building', 'pushing', 'deploying', 'running', 'stopped', 'failed', 'deleted')),
+        status_message TEXT,
+        last_status_change TIMESTAMP DEFAULT NOW(),
+
+        -- Usage tracking
+        request_count INTEGER DEFAULT 0,
+        last_request_at TIMESTAMP,
+
+        -- Lifecycle timestamps
+        created_at TIMESTAMP DEFAULT NOW(),
+        updated_at TIMESTAMP DEFAULT NOW(),
+        deployed_at TIMESTAMP,
+        stopped_at TIMESTAMP,
+        deleted_at TIMESTAMP,
+
+        -- Metadata (JSONB for flexibility)
+        tools JSONB,           -- Array of tool definitions
+        env_var_names JSONB,   -- Required env var names (not values!)
+        config JSONB           -- Additional configuration
+      );
+
+      -- Indexes
+      CREATE INDEX idx_hosted_servers_server_id ON hosted_servers(server_id);
+      CREATE INDEX idx_hosted_servers_status ON hosted_servers(status);
+      CREATE INDEX idx_hosted_servers_user_id ON hosted_servers(user_id);
+      CREATE INDEX idx_hosted_servers_conversation_id ON hosted_servers(conversation_id);
+      CREATE INDEX idx_hosted_servers_created_at ON hosted_servers(created_at DESC);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS hosted_servers`);
+  }
+}


### PR DESCRIPTION
## Summary
- Create migration for `hosted_servers` table with all columns for tracking hosted MCP servers
- Create `HostedServer` TypeORM entity with proper decorators and relationships
- Export entity from barrel export
- Register entity in AppModule

## Changes
- **New file**: `packages/backend/src/database/migrations/1733200000000-CreateHostedServersTable.ts`
- **New file**: `packages/backend/src/database/entities/hosted-server.entity.ts`
- **Modified**: `packages/backend/src/database/entities/index.ts` (added export)
- **Modified**: `packages/backend/src/app.module.ts` (registered entity)

## Database Schema
The `hosted_servers` table includes:
- Server identification (server_name, server_id, description)
- Container info (docker_image, image_tag)
- K8s info (k8s_namespace, k8s_deployment_name)
- Endpoint URL
- Status tracking with lifecycle timestamps
- Usage tracking (request_count, last_request_at)
- Metadata JSONB columns (tools, env_var_names, config)
- Foreign key to conversations table (ON DELETE SET NULL)
- Indexes for performance

## Test plan
- [x] Backend builds successfully with no TypeScript errors
- [ ] Migration runs successfully
- [ ] Entity works with TypeORM queries

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)