### PR TITLE
feat(hosting): Add GitHub Container Registry integration (#30)

### DIFF
--- a/k8s/06-ghcr-secret/README.md
+++ b/k8s/06-ghcr-secret/README.md
@@ -1,0 +1,92 @@
+# GHCR Pull Secret
+
+This directory contains the Kubernetes ImagePullSecret for pulling images from GitHub Container Registry (GHCR).
+
+## When is this needed?
+
+- **Private images**: Required for pulling private container images from GHCR
+- **Public images**: NOT needed - K8s can pull public images without authentication
+
+## Setup
+
+### Option 1: Using kubectl (Recommended)
+
+```bash
+# Create the secret directly using kubectl
+kubectl create secret docker-registry ghcr-pull-secret \
+  --docker-server=ghcr.io \
+  --docker-username=YOUR_GITHUB_USERNAME \
+  --docker-password=YOUR_GITHUB_PAT \
+  --docker-email=YOUR_EMAIL \
+  -n mcp-servers
+```
+
+### Option 2: Using the YAML template
+
+1. Copy the example file:
+   ```bash
+   cp ghcr-pull-secret.yaml.example ghcr-pull-secret.yaml
+   ```
+
+2. Generate the base64-encoded Docker config:
+   ```bash
+   # Create the auth string (username:token in base64)
+   AUTH=$(echo -n "YOUR_GITHUB_USERNAME:YOUR_GITHUB_PAT" | base64)
+
+   # Create the full config JSON and encode it
+   echo -n "{\"auths\":{\"ghcr.io\":{\"username\":\"YOUR_GITHUB_USERNAME\",\"password\":\"YOUR_GITHUB_PAT\",\"auth\":\"$AUTH\"}}}" | base64
+   ```
+
+3. Replace `<BASE64_ENCODED_DOCKER_CONFIG_JSON>` in the YAML file
+
+4. Apply the secret:
+   ```bash
+   kubectl apply -f ghcr-pull-secret.yaml
+   ```
+
+## GitHub PAT Requirements
+
+Your GitHub Personal Access Token needs the following scope:
+- `read:packages` - To pull container images from GHCR
+
+For the backend service that pushes images, you also need:
+- `write:packages` - To push container images to GHCR
+
+## Using the Secret in Deployments
+
+Add `imagePullSecrets` to your Pod spec:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-mcp-server
+  namespace: mcp-servers
+spec:
+  containers:
+    - name: mcp-server
+      image: ghcr.io/4eyedengineer/mcp-servers/my-server:latest
+  imagePullSecrets:
+    - name: ghcr-pull-secret
+```
+
+## Verification
+
+```bash
+# Check if secret exists
+kubectl get secret ghcr-pull-secret -n mcp-servers
+
+# Verify secret contents (careful with sensitive data)
+kubectl get secret ghcr-pull-secret -n mcp-servers -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d
+```
+
+## Troubleshooting
+
+### Image pull fails with "unauthorized"
+- Verify your GitHub PAT hasn't expired
+- Ensure the PAT has `read:packages` scope
+- Check that the username matches the PAT owner
+
+### Secret not found
+- Ensure the secret is in the `mcp-servers` namespace
+- Verify the secret name matches `ghcr-pull-secret`

--- a/k8s/06-ghcr-secret/ghcr-pull-secret.yaml.example
+++ b/k8s/06-ghcr-secret/ghcr-pull-secret.yaml.example
@@ -1,0 +1,27 @@
+# GHCR ImagePullSecret for Kubernetes
+# This secret allows K8s to pull images from GitHub Container Registry
+#
+# For PRIVATE images only - public images don't need this secret
+#
+# To generate the .dockerconfigjson value:
+# 1. Create a GitHub PAT with read:packages scope
+# 2. Run: echo -n '{"auths":{"ghcr.io":{"username":"YOUR_GITHUB_USERNAME","password":"YOUR_GITHUB_PAT","auth":"BASE64_OF_USERNAME:PAT"}}}' | base64
+#
+# Or use kubectl to create it directly:
+# kubectl create secret docker-registry ghcr-pull-secret \
+#   --docker-server=ghcr.io \
+#   --docker-username=YOUR_GITHUB_USERNAME \
+#   --docker-password=YOUR_GITHUB_PAT \
+#   --docker-email=YOUR_EMAIL \
+#   -n mcp-servers
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-pull-secret
+  namespace: mcp-servers
+type: kubernetes.io/dockerconfigjson
+data:
+  # Replace with your base64-encoded Docker config JSON
+  # Generate with: kubectl create secret docker-registry ... --dry-run=client -o yaml
+  .dockerconfigjson: <BASE64_ENCODED_DOCKER_CONFIG_JSON>

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -43,5 +43,10 @@ RATE_LIMIT_MAX=100
 DEFAULT_GIST_VISIBILITY=public
 MAX_GIST_SIZE=10485760
 
+# GitHub Container Registry (GHCR)
+GHCR_REGISTRY=ghcr.io
+GHCR_OWNER=4eyedengineer
+GHCR_REPO=mcp-servers
+
 # Optional: CORS Configuration
 # CORS_ORIGINS=http://localhost:4200,https://yourdomain.com

--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -14,6 +14,7 @@ import { DeploymentModule } from './deployment/deployment.module';
 import { ValidationModule } from './validation/validation.module';
 import { UserModule } from './user/user.module';
 import { SubscriptionModule } from './subscription/subscription.module';
+import { HostingModule } from './hosting/hosting.module';
 import { Conversation, ConversationMemory, Deployment, User, Subscription, UsageRecord, HostedServer } from './database/entities';
 
 // Basic DTO for generate endpoint
@@ -297,6 +298,7 @@ main().catch((error) => {
     ValidationModule,
     UserModule,
     SubscriptionModule,
+    HostingModule,
   ],
   controllers: [AppController],
   providers: [

--- a/packages/backend/src/hosting/hosting.module.ts
+++ b/packages/backend/src/hosting/hosting.module.ts
@@ -1,0 +1,23 @@
+import { Module, OnModuleInit, Logger } from '@nestjs/common';
+import { ContainerRegistryService } from './services/container-registry.service';
+
+@Module({
+  providers: [ContainerRegistryService],
+  exports: [ContainerRegistryService],
+})
+export class HostingModule implements OnModuleInit {
+  private readonly logger = new Logger(HostingModule.name);
+
+  constructor(private readonly containerRegistryService: ContainerRegistryService) {}
+
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.containerRegistryService.login();
+      this.logger.log('Hosting module initialized - GHCR login complete');
+    } catch (error) {
+      // Don't fail startup if GHCR login fails - it may not be configured
+      this.logger.warn(`GHCR login failed during startup: ${error.message}`);
+      this.logger.warn('Container registry features may not work properly');
+    }
+  }
+}

--- a/packages/backend/src/hosting/index.ts
+++ b/packages/backend/src/hosting/index.ts
@@ -1,0 +1,2 @@
+export * from './hosting.module';
+export * from './services/container-registry.service';

--- a/packages/backend/src/hosting/services/container-registry.service.ts
+++ b/packages/backend/src/hosting/services/container-registry.service.ts
@@ -1,0 +1,176 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import axios from 'axios';
+
+const execAsync = promisify(exec);
+
+@Injectable()
+export class ContainerRegistryService {
+  private readonly logger = new Logger(ContainerRegistryService.name);
+  private readonly registry: string;
+  private readonly owner: string;
+  private readonly repo: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.registry = this.configService.get<string>('GHCR_REGISTRY', 'ghcr.io');
+    this.owner = this.configService.get<string>('GHCR_OWNER');
+    this.repo = this.configService.get<string>('GHCR_REPO', 'mcp-servers');
+  }
+
+  /**
+   * Get full image name for a server
+   */
+  getImageName(serverId: string, tag: string = 'latest'): string {
+    return `${this.registry}/${this.owner}/${this.repo}/${serverId}:${tag}`;
+  }
+
+  /**
+   * Login to GHCR using GitHub token
+   */
+  async login(): Promise<void> {
+    const token = this.configService.get<string>('GITHUB_TOKEN');
+    if (!token) {
+      this.logger.warn('GITHUB_TOKEN not configured - GHCR login skipped');
+      return;
+    }
+
+    if (!this.owner) {
+      this.logger.warn('GHCR_OWNER not configured - GHCR login skipped');
+      return;
+    }
+
+    try {
+      // Use stdin for password to avoid shell escaping issues
+      await execAsync(
+        `echo "${token}" | docker login ${this.registry} -u ${this.owner} --password-stdin`
+      );
+      this.logger.log(`Logged in to GHCR (${this.registry}) as ${this.owner}`);
+    } catch (error) {
+      this.logger.error(`Failed to login to GHCR: ${error.message}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Build and push Docker image to GHCR
+   */
+  async buildAndPush(
+    serverDir: string,
+    serverId: string,
+    tag: string = 'latest'
+  ): Promise<string> {
+    const imageName = this.getImageName(serverId, tag);
+
+    // Build the image
+    this.logger.log(`Building image: ${imageName}`);
+    try {
+      const { stdout: buildOutput } = await execAsync(
+        `docker build -t ${imageName} ${serverDir}`,
+        { maxBuffer: 10 * 1024 * 1024 } // 10MB buffer for build output
+      );
+      this.logger.debug(`Build output: ${buildOutput}`);
+    } catch (error) {
+      this.logger.error(`Failed to build image: ${error.message}`);
+      throw new Error(`Docker build failed: ${error.message}`);
+    }
+
+    // Push the image
+    this.logger.log(`Pushing image: ${imageName}`);
+    try {
+      const { stdout: pushOutput } = await execAsync(`docker push ${imageName}`);
+      this.logger.debug(`Push output: ${pushOutput}`);
+    } catch (error) {
+      this.logger.error(`Failed to push image: ${error.message}`);
+      throw new Error(`Docker push failed: ${error.message}`);
+    }
+
+    this.logger.log(`Successfully pushed image: ${imageName}`);
+    return imageName;
+  }
+
+  /**
+   * Delete image from GHCR using GitHub API
+   */
+  async deleteImage(serverId: string): Promise<void> {
+    const token = this.configService.get<string>('GITHUB_TOKEN');
+    if (!token) {
+      throw new Error('GITHUB_TOKEN not configured');
+    }
+
+    // GHCR package name includes the repo path
+    const packageName = `${this.repo}/${serverId}`;
+    const url = `https://api.github.com/user/packages/container/${encodeURIComponent(packageName)}`;
+
+    try {
+      await axios.delete(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+      this.logger.log(`Deleted image from GHCR: ${serverId}`);
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        this.logger.warn(`Image not found in GHCR: ${serverId}`);
+        return;
+      }
+      this.logger.error(`Failed to delete image: ${error.message}`);
+      throw new Error(`Failed to delete image from GHCR: ${error.message}`);
+    }
+  }
+
+  /**
+   * Check if an image exists in GHCR
+   */
+  async imageExists(serverId: string, tag: string = 'latest'): Promise<boolean> {
+    const token = this.configService.get<string>('GITHUB_TOKEN');
+    if (!token) {
+      return false;
+    }
+
+    const packageName = `${this.repo}/${serverId}`;
+    const url = `https://api.github.com/user/packages/container/${encodeURIComponent(packageName)}/versions`;
+
+    try {
+      const response = await axios.get(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+
+      // Check if the specific tag exists
+      const versions = response.data as Array<{ metadata?: { container?: { tags?: string[] } } }>;
+      return versions.some(
+        (v) => v.metadata?.container?.tags?.includes(tag)
+      );
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Tag an existing image with a new tag
+   */
+  async tagImage(serverId: string, sourceTag: string, targetTag: string): Promise<string> {
+    const sourceImage = this.getImageName(serverId, sourceTag);
+    const targetImage = this.getImageName(serverId, targetTag);
+
+    try {
+      await execAsync(`docker tag ${sourceImage} ${targetImage}`);
+      await execAsync(`docker push ${targetImage}`);
+      this.logger.log(`Tagged ${sourceImage} as ${targetImage}`);
+      return targetImage;
+    } catch (error) {
+      this.logger.error(`Failed to tag image: ${error.message}`);
+      throw new Error(`Failed to tag image: ${error.message}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Implements `ContainerRegistryService` for building and pushing Docker images to GitHub Container Registry (GHCR)
- Creates `HostingModule` with automatic GHCR login on startup
- Adds K8s `ImagePullSecret` template for pulling private images

## Changes

### New Files
- `packages/backend/src/hosting/hosting.module.ts` - NestJS module with OnModuleInit for login
- `packages/backend/src/hosting/services/container-registry.service.ts` - Core GHCR service
- `k8s/06-ghcr-secret/ghcr-pull-secret.yaml.example` - K8s secret template
- `k8s/06-ghcr-secret/README.md` - Setup documentation

### Modified Files
- `packages/backend/.env.example` - Added GHCR environment variables
- `packages/backend/src/app.module.ts` - Imported HostingModule

## ContainerRegistryService Methods
- `getImageName(serverId, tag)` - Generate full GHCR image name
- `login()` - Docker login to GHCR using GITHUB_TOKEN
- `buildAndPush(serverDir, serverId, tag)` - Build and push image
- `deleteImage(serverId)` - Delete image via GitHub API
- `imageExists(serverId, tag)` - Check if image exists
- `tagImage(serverId, sourceTag, targetTag)` - Tag and push image

## Test Plan
- [ ] Verify ContainerRegistryService compiles without errors
- [ ] Test Docker login to GHCR with valid GITHUB_TOKEN
- [ ] Build and push a test image
- [ ] Verify image appears in GitHub Packages
- [ ] Test image deletion
- [ ] Create ImagePullSecret in K8s cluster
- [ ] Verify K8s can pull images from GHCR

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)