### PR TITLE
feat(hosting): Add K8s manifest generator service (#32)

### DIFF
--- a/packages/backend/src/hosting/hosting.module.ts
+++ b/packages/backend/src/hosting/hosting.module.ts
@@ -1,9 +1,10 @@
 import { Module, OnModuleInit, Logger } from '@nestjs/common';
 import { ContainerRegistryService } from './services/container-registry.service';
+import { ManifestGeneratorService } from './services/manifest-generator.service';
 
 @Module({
-  providers: [ContainerRegistryService],
-  exports: [ContainerRegistryService],
+  providers: [ContainerRegistryService, ManifestGeneratorService],
+  exports: [ContainerRegistryService, ManifestGeneratorService],
 })
 export class HostingModule implements OnModuleInit {
   private readonly logger = new Logger(HostingModule.name);

--- a/packages/backend/src/hosting/index.ts
+++ b/packages/backend/src/hosting/index.ts
@@ -1,2 +1,3 @@
 export * from './hosting.module';
 export * from './services/container-registry.service';
+export * from './services/manifest-generator.service';

--- a/packages/backend/src/hosting/services/manifest-generator.service.spec.ts
+++ b/packages/backend/src/hosting/services/manifest-generator.service.spec.ts
@@ -1,0 +1,238 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as yaml from 'js-yaml';
+import {
+  ManifestGeneratorService,
+  ManifestConfig,
+} from './manifest-generator.service';
+
+describe('ManifestGeneratorService', () => {
+  let service: ManifestGeneratorService;
+
+  const baseConfig: ManifestConfig = {
+    serverId: 'stripe-abc123',
+    serverName: 'stripe-mcp',
+    dockerImage: 'ghcr.io/4eyedengineer/mcp-servers/stripe-abc123',
+    imageTag: 'latest',
+    domain: 'mcp.example.com',
+    namespace: 'mcp-servers',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ManifestGeneratorService],
+    }).compile();
+
+    service = module.get<ManifestGeneratorService>(ManifestGeneratorService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('generateManifests', () => {
+    it('should return all three manifest types', () => {
+      const manifests = service.generateManifests(baseConfig);
+
+      expect(manifests.deployment).toBeDefined();
+      expect(manifests.service).toBeDefined();
+      expect(manifests.ingress).toBeDefined();
+    });
+  });
+
+  describe('generateDeployment', () => {
+    it('should generate valid Deployment YAML', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const deployment = yaml.load(manifests.deployment) as any;
+
+      expect(deployment.kind).toBe('Deployment');
+      expect(deployment.apiVersion).toBe('apps/v1');
+      expect(deployment.metadata.name).toBe('mcp-stripe-abc123');
+      expect(deployment.metadata.namespace).toBe('mcp-servers');
+    });
+
+    it('should include correct labels', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const deployment = yaml.load(manifests.deployment) as any;
+
+      expect(deployment.metadata.labels.app).toBe('mcp-server');
+      expect(deployment.metadata.labels['server-id']).toBe('stripe-abc123');
+      expect(deployment.metadata.labels['server-name']).toBe('stripe-mcp');
+    });
+
+    it('should use default resource limits', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const deployment = yaml.load(manifests.deployment) as any;
+      const container = deployment.spec.template.spec.containers[0];
+
+      expect(container.resources.requests.cpu).toBe('100m');
+      expect(container.resources.requests.memory).toBe('128Mi');
+      expect(container.resources.limits.cpu).toBe('500m');
+      expect(container.resources.limits.memory).toBe('256Mi');
+    });
+
+    it('should allow custom resource limits', () => {
+      const config: ManifestConfig = {
+        ...baseConfig,
+        resources: {
+          cpuRequest: '200m',
+          cpuLimit: '1000m',
+          memoryRequest: '256Mi',
+          memoryLimit: '512Mi',
+        },
+      };
+
+      const manifests = service.generateManifests(config);
+      const deployment = yaml.load(manifests.deployment) as any;
+      const container = deployment.spec.template.spec.containers[0];
+
+      expect(container.resources.requests.cpu).toBe('200m');
+      expect(container.resources.requests.memory).toBe('256Mi');
+      expect(container.resources.limits.cpu).toBe('1000m');
+      expect(container.resources.limits.memory).toBe('512Mi');
+    });
+
+    it('should include environment variables', () => {
+      const config: ManifestConfig = {
+        ...baseConfig,
+        envVars: {
+          API_KEY: 'test-key',
+          DEBUG: 'true',
+        },
+      };
+
+      const manifests = service.generateManifests(config);
+      const deployment = yaml.load(manifests.deployment) as any;
+      const container = deployment.spec.template.spec.containers[0];
+
+      const envVars = container.env;
+      expect(envVars).toContainEqual({ name: 'MCP_SERVER_ID', value: 'stripe-abc123' });
+      expect(envVars).toContainEqual({ name: 'PORT', value: '3000' });
+      expect(envVars).toContainEqual({ name: 'API_KEY', value: 'test-key' });
+      expect(envVars).toContainEqual({ name: 'DEBUG', value: 'true' });
+    });
+
+    it('should include health probes', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const deployment = yaml.load(manifests.deployment) as any;
+      const container = deployment.spec.template.spec.containers[0];
+
+      expect(container.livenessProbe.httpGet.path).toBe('/health');
+      expect(container.livenessProbe.httpGet.port).toBe(3000);
+      expect(container.readinessProbe.httpGet.path).toBe('/health');
+      expect(container.readinessProbe.httpGet.port).toBe(3000);
+    });
+
+    it('should set correct container image', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const deployment = yaml.load(manifests.deployment) as any;
+      const container = deployment.spec.template.spec.containers[0];
+
+      expect(container.image).toBe(
+        'ghcr.io/4eyedengineer/mcp-servers/stripe-abc123:latest',
+      );
+    });
+  });
+
+  describe('generateService', () => {
+    it('should generate valid Service YAML', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const svc = yaml.load(manifests.service) as any;
+
+      expect(svc.kind).toBe('Service');
+      expect(svc.apiVersion).toBe('v1');
+      expect(svc.metadata.name).toBe('mcp-stripe-abc123');
+      expect(svc.metadata.namespace).toBe('mcp-servers');
+    });
+
+    it('should include correct selector', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const svc = yaml.load(manifests.service) as any;
+
+      expect(svc.spec.selector.app).toBe('mcp-server');
+      expect(svc.spec.selector['server-id']).toBe('stripe-abc123');
+    });
+
+    it('should expose port 80 targeting 3000', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const svc = yaml.load(manifests.service) as any;
+
+      expect(svc.spec.ports[0].port).toBe(80);
+      expect(svc.spec.ports[0].targetPort).toBe(3000);
+      expect(svc.spec.ports[0].protocol).toBe('TCP');
+    });
+  });
+
+  describe('generateIngress', () => {
+    it('should generate valid Ingress YAML', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const ingress = yaml.load(manifests.ingress) as any;
+
+      expect(ingress.kind).toBe('Ingress');
+      expect(ingress.apiVersion).toBe('networking.k8s.io/v1');
+      expect(ingress.metadata.name).toBe('mcp-stripe-abc123');
+      expect(ingress.metadata.namespace).toBe('mcp-servers');
+    });
+
+    it('should configure TLS with correct host', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const ingress = yaml.load(manifests.ingress) as any;
+
+      expect(ingress.spec.tls[0].hosts[0]).toBe('stripe-abc123.mcp.example.com');
+      expect(ingress.spec.tls[0].secretName).toBe('mcp-stripe-abc123-tls');
+    });
+
+    it('should include nginx and cert-manager annotations', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const ingress = yaml.load(manifests.ingress) as any;
+
+      expect(ingress.metadata.annotations['kubernetes.io/ingress.class']).toBe(
+        'nginx',
+      );
+      expect(
+        ingress.metadata.annotations['cert-manager.io/cluster-issuer'],
+      ).toBe('letsencrypt-prod');
+    });
+
+    it('should configure routing to service', () => {
+      const manifests = service.generateManifests(baseConfig);
+      const ingress = yaml.load(manifests.ingress) as any;
+
+      const rule = ingress.spec.rules[0];
+      expect(rule.host).toBe('stripe-abc123.mcp.example.com');
+      expect(rule.http.paths[0].path).toBe('/');
+      expect(rule.http.paths[0].pathType).toBe('Prefix');
+      expect(rule.http.paths[0].backend.service.name).toBe('mcp-stripe-abc123');
+      expect(rule.http.paths[0].backend.service.port.number).toBe(80);
+    });
+  });
+
+  describe('generateKustomization', () => {
+    it('should generate valid Kustomization YAML', () => {
+      const kustomization = yaml.load(
+        service.generateKustomization('stripe-abc123'),
+      ) as any;
+
+      expect(kustomization.kind).toBe('Kustomization');
+      expect(kustomization.apiVersion).toBe('kustomize.config.k8s.io/v1beta1');
+    });
+
+    it('should include all manifest files as resources', () => {
+      const kustomization = yaml.load(
+        service.generateKustomization('stripe-abc123'),
+      ) as any;
+
+      expect(kustomization.resources).toContain('deployment.yaml');
+      expect(kustomization.resources).toContain('service.yaml');
+      expect(kustomization.resources).toContain('ingress.yaml');
+    });
+
+    it('should include common labels', () => {
+      const kustomization = yaml.load(
+        service.generateKustomization('stripe-abc123'),
+      ) as any;
+
+      expect(kustomization.commonLabels['managed-by']).toBe('mcp-everything');
+      expect(kustomization.commonLabels['server-id']).toBe('stripe-abc123');
+    });
+  });
+});

--- a/packages/backend/src/hosting/services/manifest-generator.service.ts
+++ b/packages/backend/src/hosting/services/manifest-generator.service.ts
@@ -1,0 +1,218 @@
+import { Injectable } from '@nestjs/common';
+import * as yaml from 'js-yaml';
+
+export interface ManifestConfig {
+  serverId: string;
+  serverName: string;
+  dockerImage: string;
+  imageTag: string;
+  domain: string; // e.g., mcp.yourdomain.com
+  namespace: string;
+  resources?: {
+    cpuRequest?: string;
+    cpuLimit?: string;
+    memoryRequest?: string;
+    memoryLimit?: string;
+  };
+  envVars?: Record<string, string>;
+}
+
+export interface GeneratedManifests {
+  deployment: string;
+  service: string;
+  ingress: string;
+}
+
+@Injectable()
+export class ManifestGeneratorService {
+  private readonly defaultResources = {
+    cpuRequest: '100m',
+    cpuLimit: '500m',
+    memoryRequest: '128Mi',
+    memoryLimit: '256Mi',
+  };
+
+  /**
+   * Generate all K8s manifests for an MCP server
+   */
+  generateManifests(config: ManifestConfig): GeneratedManifests {
+    return {
+      deployment: this.generateDeployment(config),
+      service: this.generateService(config),
+      ingress: this.generateIngress(config),
+    };
+  }
+
+  private generateDeployment(config: ManifestConfig): string {
+    const resources = { ...this.defaultResources, ...config.resources };
+
+    const deployment = {
+      apiVersion: 'apps/v1',
+      kind: 'Deployment',
+      metadata: {
+        name: `mcp-${config.serverId}`,
+        namespace: config.namespace,
+        labels: {
+          app: 'mcp-server',
+          'server-id': config.serverId,
+          'server-name': config.serverName,
+        },
+      },
+      spec: {
+        replicas: 1,
+        selector: {
+          matchLabels: {
+            app: 'mcp-server',
+            'server-id': config.serverId,
+          },
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: 'mcp-server',
+              'server-id': config.serverId,
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: 'mcp-server',
+                image: `${config.dockerImage}:${config.imageTag}`,
+                ports: [{ containerPort: 3000 }],
+                resources: {
+                  requests: {
+                    cpu: resources.cpuRequest,
+                    memory: resources.memoryRequest,
+                  },
+                  limits: {
+                    cpu: resources.cpuLimit,
+                    memory: resources.memoryLimit,
+                  },
+                },
+                env: [
+                  { name: 'MCP_SERVER_ID', value: config.serverId },
+                  { name: 'PORT', value: '3000' },
+                  ...Object.entries(config.envVars || {}).map(([name, value]) => ({
+                    name,
+                    value,
+                  })),
+                ],
+                livenessProbe: {
+                  httpGet: { path: '/health', port: 3000 },
+                  initialDelaySeconds: 10,
+                  periodSeconds: 30,
+                },
+                readinessProbe: {
+                  httpGet: { path: '/health', port: 3000 },
+                  initialDelaySeconds: 5,
+                  periodSeconds: 10,
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    return yaml.dump(deployment);
+  }
+
+  private generateService(config: ManifestConfig): string {
+    const service = {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: `mcp-${config.serverId}`,
+        namespace: config.namespace,
+        labels: {
+          app: 'mcp-server',
+          'server-id': config.serverId,
+        },
+      },
+      spec: {
+        selector: {
+          app: 'mcp-server',
+          'server-id': config.serverId,
+        },
+        ports: [
+          {
+            port: 80,
+            targetPort: 3000,
+            protocol: 'TCP',
+          },
+        ],
+      },
+    };
+
+    return yaml.dump(service);
+  }
+
+  private generateIngress(config: ManifestConfig): string {
+    const host = `${config.serverId}.${config.domain}`;
+
+    const ingress = {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'Ingress',
+      metadata: {
+        name: `mcp-${config.serverId}`,
+        namespace: config.namespace,
+        labels: {
+          app: 'mcp-server',
+          'server-id': config.serverId,
+        },
+        annotations: {
+          'kubernetes.io/ingress.class': 'nginx',
+          'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
+          'nginx.ingress.kubernetes.io/proxy-read-timeout': '300',
+          'nginx.ingress.kubernetes.io/proxy-send-timeout': '300',
+        },
+      },
+      spec: {
+        tls: [
+          {
+            hosts: [host],
+            secretName: `mcp-${config.serverId}-tls`,
+          },
+        ],
+        rules: [
+          {
+            host,
+            http: {
+              paths: [
+                {
+                  path: '/',
+                  pathType: 'Prefix',
+                  backend: {
+                    service: {
+                      name: `mcp-${config.serverId}`,
+                      port: { number: 80 },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    return yaml.dump(ingress);
+  }
+
+  /**
+   * Generate kustomization.yaml for the server directory
+   */
+  generateKustomization(serverId: string): string {
+    const kustomization = {
+      apiVersion: 'kustomize.config.k8s.io/v1beta1',
+      kind: 'Kustomization',
+      resources: ['deployment.yaml', 'service.yaml', 'ingress.yaml'],
+      commonLabels: {
+        'managed-by': 'mcp-everything',
+        'server-id': serverId,
+      },
+    };
+
+    return yaml.dump(kustomization);
+  }
+}


### PR DESCRIPTION
## Summary
- Add ManifestGeneratorService that generates Kubernetes YAML manifests for MCP servers
- Generates Deployment, Service, Ingress, and Kustomization YAML files
- Includes default resource limits (100m-500m CPU, 128Mi-256Mi memory)
- Configures health probes, TLS via cert-manager, and nginx ingress

## Changes
- Created `ManifestGeneratorService` with interfaces for config and output
- Registered service in `HostingModule`
- Added 19 unit tests validating all manifest generation

## Test plan
- [x] All 19 unit tests pass
- [x] Backend builds successfully
- [x] YAML output is valid and parseable with js-yaml

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)