### PR TITLE
feat(hosting): Add GitOps commit service (#33)

### DIFF
--- a/packages/backend/src/hosting/hosting.module.ts
+++ b/packages/backend/src/hosting/hosting.module.ts
@@ -1,10 +1,11 @@
 import { Module, OnModuleInit, Logger } from '@nestjs/common';
 import { ContainerRegistryService } from './services/container-registry.service';
 import { ManifestGeneratorService } from './services/manifest-generator.service';
+import { GitOpsService } from './services/gitops.service';
 
 @Module({
-  providers: [ContainerRegistryService, ManifestGeneratorService],
-  exports: [ContainerRegistryService, ManifestGeneratorService],
+  providers: [ContainerRegistryService, ManifestGeneratorService, GitOpsService],
+  exports: [ContainerRegistryService, ManifestGeneratorService, GitOpsService],
 })
 export class HostingModule implements OnModuleInit {
   private readonly logger = new Logger(HostingModule.name);

--- a/packages/backend/src/hosting/index.ts
+++ b/packages/backend/src/hosting/index.ts
@@ -1,3 +1,4 @@
 export * from './hosting.module';
 export * from './services/container-registry.service';
 export * from './services/manifest-generator.service';
+export * from './services/gitops.service';

--- a/packages/backend/src/hosting/services/gitops.service.spec.ts
+++ b/packages/backend/src/hosting/services/gitops.service.spec.ts
@@ -1,0 +1,331 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { GitOpsService, GitOpsCommitResult } from './gitops.service';
+import { GeneratedManifests } from './manifest-generator.service';
+
+// Mock Octokit
+jest.mock('@octokit/rest', () => ({
+  Octokit: jest.fn().mockImplementation(() => ({
+    git: {
+      getRef: jest.fn(),
+      getCommit: jest.fn(),
+      createBlob: jest.fn(),
+      createTree: jest.fn(),
+      createCommit: jest.fn(),
+      updateRef: jest.fn(),
+      getTree: jest.fn(),
+    },
+  })),
+}));
+
+describe('GitOpsService', () => {
+  let service: GitOpsService;
+  let mockOctokit: any;
+
+  const mockManifests: GeneratedManifests = {
+    deployment: 'apiVersion: apps/v1\nkind: Deployment\n...',
+    service: 'apiVersion: v1\nkind: Service\n...',
+    ingress: 'apiVersion: networking.k8s.io/v1\nkind: Ingress\n...',
+  };
+
+  const mockKustomization = 'apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n...';
+
+  const mockConfigService = {
+    get: jest.fn((key: string, defaultValue?: string) => {
+      const config: Record<string, string> = {
+        GITHUB_TOKEN: 'test-token',
+        GITOPS_OWNER: '4eyedengineer',
+        GITOPS_REPO: 'mcp-server-deployments',
+        GITOPS_BRANCH: 'main',
+      };
+      return config[key] ?? defaultValue;
+    }),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GitOpsService,
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<GitOpsService>(GitOpsService);
+    // Access the mocked Octokit instance
+    mockOctokit = (service as any).octokit;
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('deployServer', () => {
+    beforeEach(() => {
+      // Setup successful mock responses
+      mockOctokit.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'current-sha-123' } },
+      });
+
+      mockOctokit.git.getCommit.mockResolvedValue({
+        data: { tree: { sha: 'tree-sha-123' } },
+      });
+
+      mockOctokit.git.createBlob.mockResolvedValue({
+        data: { sha: 'blob-sha-123' },
+      });
+
+      mockOctokit.git.createTree.mockResolvedValue({
+        data: { sha: 'new-tree-sha-123' },
+      });
+
+      mockOctokit.git.createCommit.mockResolvedValue({
+        data: {
+          sha: 'new-commit-sha-123',
+          html_url: 'https://github.com/4eyedengineer/mcp-server-deployments/commit/new-commit-sha-123',
+        },
+      });
+
+      mockOctokit.git.updateRef.mockResolvedValue({});
+    });
+
+    it('should commit manifests to GitOps repo', async () => {
+      const result = await service.deployServer(
+        'test-server',
+        mockManifests,
+        mockKustomization,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.commitSha).toBe('new-commit-sha-123');
+      expect(result.commitUrl).toBeDefined();
+    });
+
+    it('should get current branch reference', async () => {
+      await service.deployServer('test-server', mockManifests, mockKustomization);
+
+      expect(mockOctokit.git.getRef).toHaveBeenCalledWith({
+        owner: '4eyedengineer',
+        repo: 'mcp-server-deployments',
+        ref: 'heads/main',
+      });
+    });
+
+    it('should create blobs for all manifest files', async () => {
+      await service.deployServer('test-server', mockManifests, mockKustomization);
+
+      // Should create 4 blobs: deployment, service, ingress, kustomization
+      expect(mockOctokit.git.createBlob).toHaveBeenCalledTimes(4);
+    });
+
+    it('should create tree with correct file paths', async () => {
+      await service.deployServer('test-server', mockManifests, mockKustomization);
+
+      expect(mockOctokit.git.createTree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: '4eyedengineer',
+          repo: 'mcp-server-deployments',
+          base_tree: 'tree-sha-123',
+          tree: expect.arrayContaining([
+            expect.objectContaining({ path: 'servers/test-server/deployment.yaml' }),
+            expect.objectContaining({ path: 'servers/test-server/service.yaml' }),
+            expect.objectContaining({ path: 'servers/test-server/ingress.yaml' }),
+            expect.objectContaining({ path: 'servers/test-server/kustomization.yaml' }),
+          ]),
+        }),
+      );
+    });
+
+    it('should create commit with meaningful message', async () => {
+      await service.deployServer('test-server', mockManifests, mockKustomization);
+
+      expect(mockOctokit.git.createCommit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Deploy MCP server: test-server',
+        }),
+      );
+    });
+
+    it('should update branch reference after commit', async () => {
+      await service.deployServer('test-server', mockManifests, mockKustomization);
+
+      expect(mockOctokit.git.updateRef).toHaveBeenCalledWith({
+        owner: '4eyedengineer',
+        repo: 'mcp-server-deployments',
+        ref: 'heads/main',
+        sha: 'new-commit-sha-123',
+      });
+    });
+
+    it('should handle API errors gracefully', async () => {
+      mockOctokit.git.getRef.mockRejectedValue(new Error('API rate limit exceeded'));
+
+      const result = await service.deployServer(
+        'test-server',
+        mockManifests,
+        mockKustomization,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API rate limit exceeded');
+    });
+  });
+
+  describe('removeServer', () => {
+    beforeEach(() => {
+      mockOctokit.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'current-sha-123' } },
+      });
+
+      mockOctokit.git.getCommit.mockResolvedValue({
+        data: { tree: { sha: 'tree-sha-123' } },
+      });
+
+      mockOctokit.git.getTree.mockResolvedValue({
+        data: {
+          tree: [
+            { path: 'servers/test-server/deployment.yaml', sha: 'blob1', mode: '100644', type: 'blob' },
+            { path: 'servers/test-server/service.yaml', sha: 'blob2', mode: '100644', type: 'blob' },
+            { path: 'servers/other-server/deployment.yaml', sha: 'blob3', mode: '100644', type: 'blob' },
+            { path: 'README.md', sha: 'blob4', mode: '100644', type: 'blob' },
+          ],
+        },
+      });
+
+      mockOctokit.git.createTree.mockResolvedValue({
+        data: { sha: 'new-tree-sha-123' },
+      });
+
+      mockOctokit.git.createCommit.mockResolvedValue({
+        data: {
+          sha: 'remove-commit-sha-123',
+          html_url: 'https://github.com/4eyedengineer/mcp-server-deployments/commit/remove-commit-sha-123',
+        },
+      });
+
+      mockOctokit.git.updateRef.mockResolvedValue({});
+    });
+
+    it('should remove server directory from GitOps repo', async () => {
+      const result = await service.removeServer('test-server');
+
+      expect(result.success).toBe(true);
+      expect(result.commitSha).toBe('remove-commit-sha-123');
+    });
+
+    it('should filter out files from server directory', async () => {
+      await service.removeServer('test-server');
+
+      expect(mockOctokit.git.createTree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tree: expect.not.arrayContaining([
+            expect.objectContaining({ path: 'servers/test-server/deployment.yaml' }),
+            expect.objectContaining({ path: 'servers/test-server/service.yaml' }),
+          ]),
+        }),
+      );
+
+      // Should preserve other files
+      expect(mockOctokit.git.createTree).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tree: expect.arrayContaining([
+            expect.objectContaining({ path: 'servers/other-server/deployment.yaml' }),
+            expect.objectContaining({ path: 'README.md' }),
+          ]),
+        }),
+      );
+    });
+
+    it('should create commit with removal message', async () => {
+      await service.removeServer('test-server');
+
+      expect(mockOctokit.git.createCommit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Remove MCP server: test-server',
+        }),
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      mockOctokit.git.getRef.mockRejectedValue(new Error('Network error'));
+
+      const result = await service.removeServer('test-server');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Network error');
+    });
+  });
+
+  describe('updateServer', () => {
+    beforeEach(() => {
+      mockOctokit.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'current-sha-123' } },
+      });
+
+      mockOctokit.git.getCommit.mockResolvedValue({
+        data: { tree: { sha: 'tree-sha-123' } },
+      });
+
+      mockOctokit.git.createBlob.mockResolvedValue({
+        data: { sha: 'blob-sha-123' },
+      });
+
+      mockOctokit.git.createTree.mockResolvedValue({
+        data: { sha: 'new-tree-sha-123' },
+      });
+
+      mockOctokit.git.createCommit.mockResolvedValue({
+        data: {
+          sha: 'update-commit-sha-123',
+          html_url: 'https://github.com/4eyedengineer/mcp-server-deployments/commit/update-commit-sha-123',
+        },
+      });
+
+      mockOctokit.git.updateRef.mockResolvedValue({});
+    });
+
+    it('should update server by overwriting manifests', async () => {
+      const result = await service.updateServer(
+        'test-server',
+        mockManifests,
+        mockKustomization,
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.commitSha).toBe('update-commit-sha-123');
+    });
+
+    it('should use same logic as deployServer', async () => {
+      // updateServer is a wrapper around deployServer
+      const deploySpy = jest.spyOn(service, 'deployServer');
+
+      await service.updateServer('test-server', mockManifests, mockKustomization);
+
+      expect(deploySpy).toHaveBeenCalledWith(
+        'test-server',
+        mockManifests,
+        mockKustomization,
+      );
+    });
+  });
+
+  describe('configuration', () => {
+    it('should use default values when config not provided', () => {
+      const configWithDefaults = {
+        get: jest.fn((key: string, defaultValue?: string) => {
+          if (key === 'GITHUB_TOKEN') return 'test-token';
+          return defaultValue;
+        }),
+      };
+
+      // Create new module with defaults
+      const testService = new GitOpsService(configWithDefaults as any);
+
+      // Access private properties to verify defaults
+      expect((testService as any).owner).toBe('4eyedengineer');
+      expect((testService as any).repo).toBe('mcp-server-deployments');
+      expect((testService as any).branch).toBe('main');
+    });
+  });
+});

--- a/packages/backend/src/hosting/services/gitops.service.ts
+++ b/packages/backend/src/hosting/services/gitops.service.ts
@@ -1,0 +1,217 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Octokit } from '@octokit/rest';
+import { GeneratedManifests } from './manifest-generator.service';
+
+export interface GitOpsCommitResult {
+  success: boolean;
+  commitSha?: string;
+  commitUrl?: string;
+  error?: string;
+}
+
+@Injectable()
+export class GitOpsService {
+  private readonly logger = new Logger(GitOpsService.name);
+  private readonly octokit: Octokit;
+  private readonly owner: string;
+  private readonly repo: string;
+  private readonly branch: string;
+
+  constructor(private configService: ConfigService) {
+    this.octokit = new Octokit({
+      auth: this.configService.get('GITHUB_TOKEN'),
+    });
+    this.owner = this.configService.get('GITOPS_OWNER', '4eyedengineer');
+    this.repo = this.configService.get('GITOPS_REPO', 'mcp-server-deployments');
+    this.branch = this.configService.get('GITOPS_BRANCH', 'main');
+  }
+
+  /**
+   * Deploy server by committing manifests to GitOps repo
+   */
+  async deployServer(
+    serverId: string,
+    manifests: GeneratedManifests,
+    kustomization: string,
+  ): Promise<GitOpsCommitResult> {
+    try {
+      const basePath = `servers/${serverId}`;
+
+      // Get current commit SHA for the branch
+      const { data: ref } = await this.octokit.git.getRef({
+        owner: this.owner,
+        repo: this.repo,
+        ref: `heads/${this.branch}`,
+      });
+      const currentSha = ref.object.sha;
+
+      // Get current tree
+      const { data: currentCommit } = await this.octokit.git.getCommit({
+        owner: this.owner,
+        repo: this.repo,
+        commit_sha: currentSha,
+      });
+
+      // Create blobs for each file
+      const files = [
+        { path: `${basePath}/deployment.yaml`, content: manifests.deployment },
+        { path: `${basePath}/service.yaml`, content: manifests.service },
+        { path: `${basePath}/ingress.yaml`, content: manifests.ingress },
+        { path: `${basePath}/kustomization.yaml`, content: kustomization },
+      ];
+
+      const blobs = await Promise.all(
+        files.map(async (file) => {
+          const { data: blob } = await this.octokit.git.createBlob({
+            owner: this.owner,
+            repo: this.repo,
+            content: Buffer.from(file.content).toString('base64'),
+            encoding: 'base64',
+          });
+          return {
+            path: file.path,
+            mode: '100644' as const,
+            type: 'blob' as const,
+            sha: blob.sha,
+          };
+        }),
+      );
+
+      // Create new tree
+      const { data: newTree } = await this.octokit.git.createTree({
+        owner: this.owner,
+        repo: this.repo,
+        base_tree: currentCommit.tree.sha,
+        tree: blobs,
+      });
+
+      // Create commit
+      const { data: newCommit } = await this.octokit.git.createCommit({
+        owner: this.owner,
+        repo: this.repo,
+        message: `Deploy MCP server: ${serverId}`,
+        tree: newTree.sha,
+        parents: [currentSha],
+      });
+
+      // Update branch reference
+      await this.octokit.git.updateRef({
+        owner: this.owner,
+        repo: this.repo,
+        ref: `heads/${this.branch}`,
+        sha: newCommit.sha,
+      });
+
+      this.logger.log(`Committed manifests for ${serverId}: ${newCommit.sha}`);
+
+      return {
+        success: true,
+        commitSha: newCommit.sha,
+        commitUrl: newCommit.html_url,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Failed to commit manifests for ${serverId}: ${error.message}`,
+      );
+      return {
+        success: false,
+        error: error.message,
+      };
+    }
+  }
+
+  /**
+   * Remove server by deleting its directory from GitOps repo
+   */
+  async removeServer(serverId: string): Promise<GitOpsCommitResult> {
+    try {
+      const basePath = `servers/${serverId}`;
+
+      // Get current commit SHA
+      const { data: ref } = await this.octokit.git.getRef({
+        owner: this.owner,
+        repo: this.repo,
+        ref: `heads/${this.branch}`,
+      });
+      const currentSha = ref.object.sha;
+
+      // Get current tree
+      const { data: currentCommit } = await this.octokit.git.getCommit({
+        owner: this.owner,
+        repo: this.repo,
+        commit_sha: currentSha,
+      });
+
+      // Get full tree (recursive)
+      const { data: fullTree } = await this.octokit.git.getTree({
+        owner: this.owner,
+        repo: this.repo,
+        tree_sha: currentCommit.tree.sha,
+        recursive: 'true',
+      });
+
+      // Filter out files in the server directory
+      const newTreeItems = fullTree.tree.filter(
+        (item) => !item.path?.startsWith(basePath),
+      );
+
+      // Create new tree without the server directory
+      const { data: newTree } = await this.octokit.git.createTree({
+        owner: this.owner,
+        repo: this.repo,
+        tree: newTreeItems.map((item) => ({
+          path: item.path!,
+          mode: item.mode as '100644' | '100755' | '040000' | '160000' | '120000',
+          type: item.type as 'blob' | 'tree' | 'commit',
+          sha: item.sha,
+        })),
+      });
+
+      // Create commit
+      const { data: newCommit } = await this.octokit.git.createCommit({
+        owner: this.owner,
+        repo: this.repo,
+        message: `Remove MCP server: ${serverId}`,
+        tree: newTree.sha,
+        parents: [currentSha],
+      });
+
+      // Update branch
+      await this.octokit.git.updateRef({
+        owner: this.owner,
+        repo: this.repo,
+        ref: `heads/${this.branch}`,
+        sha: newCommit.sha,
+      });
+
+      this.logger.log(`Removed manifests for ${serverId}: ${newCommit.sha}`);
+
+      return {
+        success: true,
+        commitSha: newCommit.sha,
+        commitUrl: newCommit.html_url,
+      };
+    } catch (error) {
+      this.logger.error(
+        `Failed to remove manifests for ${serverId}: ${error.message}`,
+      );
+      return {
+        success: false,
+        error: error.message,
+      };
+    }
+  }
+
+  /**
+   * Update server (e.g., new image tag)
+   */
+  async updateServer(
+    serverId: string,
+    manifests: GeneratedManifests,
+    kustomization: string,
+  ): Promise<GitOpsCommitResult> {
+    // Same as deploy, will overwrite existing files
+    return this.deployServer(serverId, manifests, kustomization);
+  }
+}


### PR DESCRIPTION
## Summary
- Add GitOpsService that commits K8s manifests to the GitOps repository
- Uses Octokit for GitHub Git API operations (create blobs, trees, commits)
- Supports deploy, remove, and update operations for MCP servers
- Comprehensive unit tests (15 tests passing)

## Changes
- `gitops.service.ts` - Main service with deployServer, removeServer, updateServer
- `gitops.service.spec.ts` - Unit tests with mocked Octokit
- Updated `hosting.module.ts` to include GitOpsService
- Updated `index.ts` exports

## Flow
```
HostingService.deploy()
       │
       ▼
ManifestGeneratorService.generateManifests()
       │
       ▼
GitOpsService.deployServer()
       │
       ├─ Create blobs for each YAML file
       ├─ Create new tree with blobs
       ├─ Create commit
       └─ Update branch reference
              │
              ▼
       ArgoCD detects new commit
              │
              ▼
       ArgoCD syncs manifests to cluster
```

## Test plan
- [x] Unit tests pass (15 tests)
- [x] TypeScript compiles without errors
- [ ] Integration test with real GitOps repo (manual)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)