### PR TITLE
feat(hosting): Add Hosting Controller API endpoints (#36)

### DIFF
--- a/packages/backend/src/hosting/dto/deploy-server.dto.ts
+++ b/packages/backend/src/hosting/dto/deploy-server.dto.ts
@@ -1,0 +1,13 @@
+import { IsString, IsOptional, MaxLength } from 'class-validator';
+
+export class DeployServerDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  serverName?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  description?: string;
+}

--- a/packages/backend/src/hosting/dto/index.ts
+++ b/packages/backend/src/hosting/dto/index.ts
@@ -1,0 +1,3 @@
+export * from './deploy-server.dto';
+export * from './server-response.dto';
+export * from './server-status.dto';

--- a/packages/backend/src/hosting/dto/server-response.dto.ts
+++ b/packages/backend/src/hosting/dto/server-response.dto.ts
@@ -1,0 +1,15 @@
+export class ServerResponseDto {
+  id: string;
+  serverId: string;
+  serverName: string;
+  description?: string;
+  endpointUrl: string;
+  status: string;
+  statusMessage?: string;
+  tools: Array<{ name: string; description: string; inputSchema: any }>;
+  requestCount: number;
+  lastRequestAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  deployedAt?: Date;
+}

--- a/packages/backend/src/hosting/dto/server-status.dto.ts
+++ b/packages/backend/src/hosting/dto/server-status.dto.ts
@@ -1,0 +1,8 @@
+export class ServerStatusDto {
+  serverId: string;
+  status: string;
+  message: string;
+  replicas: number;
+  readyReplicas: number;
+  lastUpdated: Date;
+}

--- a/packages/backend/src/hosting/hosting.controller.ts
+++ b/packages/backend/src/hosting/hosting.controller.ts
@@ -1,0 +1,223 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Param,
+  Query,
+  Body,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { HostingService } from './hosting.service';
+import { DeployServerDto } from './dto/deploy-server.dto';
+
+@Controller('api/hosting')
+export class HostingController {
+  private readonly logger = new Logger(HostingController.name);
+
+  constructor(private readonly hostingService: HostingService) {}
+
+  /**
+   * Deploy a generated MCP server to Kubernetes
+   */
+  @Post('deploy/:conversationId')
+  async deployServer(
+    @Param('conversationId') conversationId: string,
+    @Body() dto: DeployServerDto,
+  ) {
+    try {
+      this.logger.log(`Deploying server for conversation: ${conversationId}`);
+
+      const result = await this.hostingService.deployToCloud(conversationId);
+
+      return {
+        success: result.success,
+        serverId: result.serverId,
+        endpointUrl: result.endpointUrl,
+        status: result.status,
+        error: result.error,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Deploy failed: ${message}`);
+      throw new HttpException(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * List all hosted servers for the current user
+   */
+  @Get('servers')
+  async listServers(
+    @Query('status') status?: string,
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 20,
+  ) {
+    // TODO: Get userId from auth context when auth is implemented
+    const servers = await this.hostingService.getServers();
+
+    // Filter by status if provided
+    let filteredServers = servers;
+    if (status) {
+      filteredServers = servers.filter((s) => s.status === status);
+    }
+
+    // Apply pagination
+    const startIndex = (page - 1) * limit;
+    const endIndex = startIndex + limit;
+    const paginatedServers = filteredServers.slice(startIndex, endIndex);
+
+    return {
+      servers: paginatedServers.map((server) => ({
+        id: server.id,
+        serverId: server.serverId,
+        serverName: server.serverName,
+        description: server.description,
+        endpointUrl: server.endpointUrl,
+        status: server.status,
+        statusMessage: server.statusMessage,
+        tools: server.tools,
+        requestCount: server.requestCount,
+        lastRequestAt: server.lastRequestAt,
+        createdAt: server.createdAt,
+        updatedAt: server.updatedAt,
+        deployedAt: server.deployedAt,
+      })),
+      pagination: {
+        page,
+        limit,
+        total: filteredServers.length,
+        totalPages: Math.ceil(filteredServers.length / limit),
+      },
+    };
+  }
+
+  /**
+   * Get details of a specific hosted server
+   */
+  @Get('servers/:serverId')
+  async getServer(@Param('serverId') serverId: string) {
+    const server = await this.hostingService.getServer(serverId);
+
+    return {
+      id: server.id,
+      serverId: server.serverId,
+      serverName: server.serverName,
+      description: server.description,
+      endpointUrl: server.endpointUrl,
+      status: server.status,
+      statusMessage: server.statusMessage,
+      dockerImage: server.dockerImage,
+      imageTag: server.imageTag,
+      k8sNamespace: server.k8sNamespace,
+      k8sDeploymentName: server.k8sDeploymentName,
+      tools: server.tools,
+      envVarNames: server.envVarNames,
+      requestCount: server.requestCount,
+      lastRequestAt: server.lastRequestAt,
+      createdAt: server.createdAt,
+      updatedAt: server.updatedAt,
+      deployedAt: server.deployedAt,
+      stoppedAt: server.stoppedAt,
+    };
+  }
+
+  /**
+   * Get real-time deployment status
+   */
+  @Get('servers/:serverId/status')
+  async getServerStatus(@Param('serverId') serverId: string) {
+    const server = await this.hostingService.getServer(serverId);
+
+    // Derive replica counts based on status
+    const replicas = server.status === 'stopped' ? 0 : 1;
+    const readyReplicas =
+      server.status === 'running' ? 1 : server.status === 'stopped' ? 0 : 0;
+
+    return {
+      serverId: server.serverId,
+      status: server.status,
+      message: server.statusMessage || '',
+      replicas,
+      readyReplicas,
+      lastUpdated: server.lastStatusChange || server.updatedAt,
+    };
+  }
+
+  /**
+   * Get server logs (last N lines)
+   */
+  @Get('servers/:serverId/logs')
+  async getServerLogs(
+    @Param('serverId') serverId: string,
+    @Query('lines') lines: number = 100,
+    @Query('since') since?: string,
+  ) {
+    const logs = await this.hostingService.getServerLogs(serverId, {
+      lines,
+      since,
+    });
+
+    return {
+      serverId,
+      logs: logs.logs,
+      message: logs.message,
+    };
+  }
+
+  /**
+   * Stop a hosted server (scale to 0)
+   */
+  @Post('servers/:serverId/stop')
+  async stopServer(@Param('serverId') serverId: string) {
+    try {
+      await this.hostingService.stopServer(serverId);
+
+      return {
+        success: true,
+        message: 'Server stopped successfully',
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new HttpException(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Start a stopped server (scale to 1)
+   */
+  @Post('servers/:serverId/start')
+  async startServer(@Param('serverId') serverId: string) {
+    try {
+      await this.hostingService.startServer(serverId);
+
+      return {
+        success: true,
+        message: 'Server started successfully',
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new HttpException(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  /**
+   * Delete a hosted server permanently
+   */
+  @Delete('servers/:serverId')
+  async deleteServer(@Param('serverId') serverId: string) {
+    try {
+      await this.hostingService.deleteServer(serverId);
+
+      return {
+        success: true,
+        message: 'Server deleted successfully',
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      throw new HttpException(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/packages/backend/src/hosting/hosting.module.ts
+++ b/packages/backend/src/hosting/hosting.module.ts
@@ -4,11 +4,13 @@ import { ContainerRegistryService } from './services/container-registry.service'
 import { ManifestGeneratorService } from './services/manifest-generator.service';
 import { GitOpsService } from './services/gitops.service';
 import { HostingService } from './hosting.service';
+import { HostingController } from './hosting.controller';
 import { HostedServer } from '../database/entities/hosted-server.entity';
 import { Deployment } from '../database/entities/deployment.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([HostedServer, Deployment])],
+  controllers: [HostingController],
   providers: [
     ContainerRegistryService,
     ManifestGeneratorService,

--- a/packages/backend/src/hosting/hosting.service.ts
+++ b/packages/backend/src/hosting/hosting.service.ts
@@ -294,6 +294,31 @@ export class HostingService {
     );
   }
 
+  /**
+   * Get server logs
+   * Note: Full K8s log streaming requires kubectl/K8s client integration.
+   * This is a stub that returns placeholder data.
+   */
+  async getServerLogs(
+    serverId: string,
+    options: { lines?: number; since?: string },
+  ): Promise<{ logs: string[]; message: string }> {
+    // Validate server exists
+    await this.getServerByIdOrFail(serverId);
+
+    // TODO: Implement K8s log fetching via kubectl or K8s client
+    // For now, return a placeholder indicating logs are not yet available
+    this.logger.debug(
+      `Log request for ${serverId}: lines=${options.lines}, since=${options.since}`,
+    );
+
+    return {
+      logs: [],
+      message:
+        'Log streaming not yet implemented. K8s integration required for live logs.',
+    };
+  }
+
   // --- Helper Methods ---
 
   private generateServerId(serverName: string): string {

--- a/packages/backend/src/hosting/index.ts
+++ b/packages/backend/src/hosting/index.ts
@@ -1,5 +1,7 @@
 export * from './hosting.module';
+export * from './hosting.controller';
 export * from './hosting.service';
 export * from './services/container-registry.service';
 export * from './services/manifest-generator.service';
 export * from './services/gitops.service';
+export * from './dto';


### PR DESCRIPTION
## Summary

Add NestJS controller with 8 REST API endpoints for managing hosted MCP servers:

- `POST /api/hosting/deploy/:conversationId` - Deploy server to K8s
- `GET /api/hosting/servers` - List user's hosted servers with pagination
- `GET /api/hosting/servers/:serverId` - Get server details
- `GET /api/hosting/servers/:serverId/status` - Get deployment status
- `GET /api/hosting/servers/:serverId/logs` - Get server logs (stubbed pending K8s integration)
- `POST /api/hosting/servers/:serverId/stop` - Stop server (scale to 0)
- `POST /api/hosting/servers/:serverId/start` - Start server (scale to 1)
- `DELETE /api/hosting/servers/:serverId` - Delete server

## Changes

### New Files
- `hosting.controller.ts` - Controller with all 8 endpoints
- `dto/deploy-server.dto.ts` - Request validation DTO with class-validator
- `dto/server-response.dto.ts` - Response structure DTO
- `dto/server-status.dto.ts` - Status response DTO
- `dto/index.ts` - Barrel export

### Modified Files
- `hosting.service.ts` - Added `getServerLogs()` stub method
- `hosting.module.ts` - Registered HostingController
- `index.ts` - Updated barrel exports

## Test Plan

- [ ] Verify endpoints compile and are registered
- [ ] Test deploy endpoint with valid conversation ID
- [ ] Test list servers with pagination
- [ ] Test get server details
- [ ] Test start/stop/delete operations
- [ ] Verify error handling returns appropriate HTTP status codes

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)