### PR TITLE
feat(frontend): Add Server Management Dashboard (#40)

### DIFF
--- a/packages/frontend/src/app/app-routing.module.ts
+++ b/packages/frontend/src/app/app-routing.module.ts
@@ -25,6 +25,14 @@ const routes: Routes = [
     }
   },
   {
+    path: 'servers',
+    loadChildren: () => import('./features/servers/servers.module').then(m => m.ServersModule),
+    data: {
+      title: 'My Servers',
+      description: 'Manage your hosted MCP servers'
+    }
+  },
+  {
     path: 'account',
     loadChildren: () => import('./features/account/account.module').then(m => m.AccountModule),
     data: {

--- a/packages/frontend/src/app/core/services/hosting-api.service.ts
+++ b/packages/frontend/src/app/core/services/hosting-api.service.ts
@@ -201,6 +201,23 @@ export class HostingApiService {
   }
 
   /**
+   * Get server logs
+   * @param serverId The server ID
+   * @param lines Number of log lines to retrieve (default: 100)
+   */
+  getLogs(
+    serverId: string,
+    lines: number = 100
+  ): Observable<{ logs: string[]; message: string }> {
+    return this.http
+      .get<{ logs: string[]; message: string }>(
+        `${this.baseUrl}/servers/${serverId}/logs`,
+        { params: { lines: lines.toString() } }
+      )
+      .pipe(catchError((error) => this.handleError(error, 'getLogs')));
+  }
+
+  /**
    * Handle HTTP errors
    */
   private handleError(error: HttpErrorResponse, operation: string): Observable<never> {

--- a/packages/frontend/src/app/features/servers/components/confirm-modal/confirm-modal.component.html
+++ b/packages/frontend/src/app/features/servers/components/confirm-modal/confirm-modal.component.html
@@ -1,0 +1,21 @@
+<div class="modal-overlay" (click)="onOverlayClick($event)">
+  <div class="modal-content confirm-modal">
+    <header class="modal-header">
+      <mat-icon [class.danger]="isDanger">{{ isDanger ? 'warning' : 'help_outline' }}</mat-icon>
+      <h2>{{ title }}</h2>
+    </header>
+
+    <div class="modal-body">
+      <p>{{ message }}</p>
+    </div>
+
+    <footer class="modal-footer">
+      <button mat-button (click)="onCancel()" class="btn-cancel">
+        {{ cancelText }}
+      </button>
+      <button mat-raised-button (click)="onConfirm()" [class.btn-danger]="isDanger" [class.btn-primary]="!isDanger">
+        {{ confirmText }}
+      </button>
+    </footer>
+  </div>
+</div>

--- a/packages/frontend/src/app/features/servers/components/confirm-modal/confirm-modal.component.scss
+++ b/packages/frontend/src/app/features/servers/components/confirm-modal/confirm-modal.component.scss
@@ -1,0 +1,116 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.modal-content.confirm-modal {
+  background: white;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 420px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 20px 24px 16px;
+
+  mat-icon {
+    font-size: 28px;
+    width: 28px;
+    height: 28px;
+    color: #6b6b6b;
+
+    &.danger {
+      color: #c62828;
+    }
+  }
+
+  h2 {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1f1f1f;
+    margin: 0;
+  }
+}
+
+.modal-body {
+  padding: 0 24px 20px;
+
+  p {
+    font-size: 14px;
+    line-height: 1.6;
+    color: #6b6b6b;
+    margin: 0;
+  }
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid #e5e5e5;
+  background: #f5f5f5;
+  border-radius: 0 0 12px 12px;
+
+  .btn-cancel {
+    color: #6b6b6b;
+    border-radius: 8px;
+
+    &:hover {
+      background: #e5e5e5;
+      color: #1f1f1f;
+    }
+  }
+
+  .btn-primary {
+    background-color: #2d2d2d;
+    color: white;
+    border-radius: 8px;
+
+    &:hover {
+      background-color: #1a1a1a;
+    }
+  }
+
+  .btn-danger {
+    background-color: #c62828;
+    color: white;
+    border-radius: 8px;
+
+    &:hover {
+      background-color: #b71c1c;
+    }
+  }
+}
+
+// Responsive styles
+@media (max-width: 480px) {
+  .modal-overlay {
+    padding: 16px;
+  }
+
+  .modal-content.confirm-modal {
+    max-width: 100%;
+  }
+
+  .modal-footer {
+    flex-direction: column-reverse;
+
+    button {
+      width: 100%;
+    }
+  }
+}

--- a/packages/frontend/src/app/features/servers/components/confirm-modal/confirm-modal.component.ts
+++ b/packages/frontend/src/app/features/servers/components/confirm-modal/confirm-modal.component.ts
@@ -1,0 +1,40 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'mcp-confirm-modal',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatButtonModule
+  ],
+  templateUrl: './confirm-modal.component.html',
+  styleUrls: ['./confirm-modal.component.scss']
+})
+export class ConfirmModalComponent {
+  @Input() title = 'Confirm Action';
+  @Input() message = 'Are you sure you want to proceed?';
+  @Input() confirmText = 'Confirm';
+  @Input() cancelText = 'Cancel';
+  @Input() isDanger = false;
+
+  @Output() confirm = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  onOverlayClick(event: MouseEvent): void {
+    if ((event.target as HTMLElement).classList.contains('modal-overlay')) {
+      this.cancel.emit();
+    }
+  }
+
+  onConfirm(): void {
+    this.confirm.emit();
+  }
+
+  onCancel(): void {
+    this.cancel.emit();
+  }
+}

--- a/packages/frontend/src/app/features/servers/components/logs-modal/logs-modal.component.html
+++ b/packages/frontend/src/app/features/servers/components/logs-modal/logs-modal.component.html
@@ -1,0 +1,64 @@
+<div class="modal-overlay" (click)="onOverlayClick($event)">
+  <div class="modal-content logs-modal">
+    <header class="modal-header">
+      <div class="header-title">
+        <mat-icon>article</mat-icon>
+        <h2>Logs: {{ server.serverId }}</h2>
+      </div>
+      <button mat-icon-button (click)="onClose()" class="close-btn">
+        <mat-icon>close</mat-icon>
+      </button>
+    </header>
+
+    <div class="modal-body">
+      <!-- Loading State -->
+      <div *ngIf="isLoading" class="loading-state">
+        <mat-spinner diameter="32"></mat-spinner>
+        <p>Loading logs...</p>
+      </div>
+
+      <!-- Error State -->
+      <div *ngIf="error && !isLoading" class="error-state">
+        <mat-icon>error_outline</mat-icon>
+        <p>{{ error }}</p>
+      </div>
+
+      <!-- Logs Content -->
+      <div *ngIf="!isLoading && !error" class="logs-container">
+        <div *ngIf="message" class="logs-message">
+          <mat-icon>info</mat-icon>
+          <span>{{ message }}</span>
+        </div>
+
+        <div *ngIf="logs.length === 0" class="empty-logs">
+          <mat-icon>description</mat-icon>
+          <p>No logs available</p>
+        </div>
+
+        <pre *ngIf="logs.length > 0" class="logs-content"><ng-container *ngFor="let line of logs">{{ line }}
+</ng-container></pre>
+      </div>
+    </div>
+
+    <footer class="modal-footer">
+      <mat-form-field appearance="outline" class="line-count-select">
+        <mat-select [(value)]="lineCount" (selectionChange)="refreshLogs()">
+          <mat-option *ngFor="let option of lineCountOptions" [value]="option.value">
+            {{ option.label }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <div class="footer-actions">
+        <button mat-button (click)="refreshLogs()" class="btn-secondary">
+          <mat-icon>refresh</mat-icon>
+          Refresh
+        </button>
+        <button mat-button (click)="downloadLogs()" class="btn-secondary" [disabled]="logs.length === 0">
+          <mat-icon>download</mat-icon>
+          Download
+        </button>
+      </div>
+    </footer>
+  </div>
+</div>

--- a/packages/frontend/src/app/features/servers/components/logs-modal/logs-modal.component.scss
+++ b/packages/frontend/src/app/features/servers/components/logs-modal/logs-modal.component.scss
@@ -1,0 +1,245 @@
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.modal-content.logs-modal {
+  background: white;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 900px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e5e5e5;
+
+  .header-title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+
+    mat-icon {
+      font-size: 24px;
+      width: 24px;
+      height: 24px;
+      color: #6b6b6b;
+    }
+
+    h2 {
+      font-size: 18px;
+      font-weight: 600;
+      color: #1f1f1f;
+      margin: 0;
+    }
+  }
+
+  .close-btn {
+    color: #6b6b6b;
+
+    &:hover {
+      color: #1f1f1f;
+    }
+  }
+}
+
+.modal-body {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.loading-state,
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  text-align: center;
+
+  mat-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+    color: #6b6b6b;
+    margin-bottom: 16px;
+  }
+
+  p {
+    color: #6b6b6b;
+    font-size: 14px;
+    margin: 8px 0 0;
+  }
+}
+
+.error-state {
+  mat-icon {
+    color: #c62828;
+  }
+}
+
+.logs-container {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  .logs-message {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 20px;
+    background: #fff8e1;
+    border-bottom: 1px solid #ffe0b2;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      color: #f57c00;
+    }
+
+    span {
+      font-size: 13px;
+      color: #e65100;
+    }
+  }
+
+  .empty-logs {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 24px;
+    text-align: center;
+
+    mat-icon {
+      font-size: 48px;
+      width: 48px;
+      height: 48px;
+      color: #e5e5e5;
+      margin-bottom: 16px;
+    }
+
+    p {
+      color: #6b6b6b;
+      font-size: 14px;
+      margin: 0;
+    }
+  }
+
+  .logs-content {
+    flex: 1;
+    overflow: auto;
+    margin: 0;
+    padding: 16px 20px;
+    background: #1f1f1f;
+    color: #e5e5e5;
+    font-family: 'Fira Code', 'Monaco', 'Consolas', monospace;
+    font-size: 12px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  border-top: 1px solid #e5e5e5;
+  background: #f5f5f5;
+
+  .line-count-select {
+    width: 160px;
+
+    ::ng-deep {
+      .mat-mdc-form-field-subscript-wrapper {
+        display: none;
+      }
+
+      .mat-mdc-text-field-wrapper {
+        padding: 0 8px;
+        background: white;
+      }
+
+      .mat-mdc-form-field-infix {
+        padding: 8px 0;
+        min-height: 36px;
+      }
+    }
+  }
+
+  .footer-actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  .btn-secondary {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #6b6b6b;
+    border-radius: 8px;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover {
+      background: #e5e5e5;
+      color: #1f1f1f;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+}
+
+// Responsive styles
+@media (max-width: 768px) {
+  .modal-overlay {
+    padding: 16px;
+  }
+
+  .modal-content.logs-modal {
+    max-height: 90vh;
+  }
+
+  .modal-footer {
+    flex-direction: column;
+    gap: 12px;
+
+    .line-count-select {
+      width: 100%;
+    }
+
+    .footer-actions {
+      width: 100%;
+      justify-content: flex-end;
+    }
+  }
+}

--- a/packages/frontend/src/app/features/servers/components/logs-modal/logs-modal.component.ts
+++ b/packages/frontend/src/app/features/servers/components/logs-modal/logs-modal.component.ts
@@ -1,0 +1,87 @@
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+import { HostedServer } from '../../../../core/services/hosting-api.service';
+import { HostingApiService } from '../../../../core/services/hosting-api.service';
+
+@Component({
+  selector: 'mcp-logs-modal',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSelectModule,
+    MatFormFieldModule,
+    MatProgressSpinnerModule
+  ],
+  templateUrl: './logs-modal.component.html',
+  styleUrls: ['./logs-modal.component.scss']
+})
+export class LogsModalComponent implements OnInit {
+  @Input() server!: HostedServer;
+  @Output() close = new EventEmitter<void>();
+
+  logs: string[] = [];
+  message = '';
+  isLoading = true;
+  error: string | null = null;
+  lineCount = 100;
+
+  lineCountOptions = [
+    { value: 50, label: 'Last 50 lines' },
+    { value: 100, label: 'Last 100 lines' },
+    { value: 500, label: 'Last 500 lines' }
+  ];
+
+  constructor(private hostingApiService: HostingApiService) {}
+
+  ngOnInit(): void {
+    this.refreshLogs();
+  }
+
+  refreshLogs(): void {
+    this.isLoading = true;
+    this.error = null;
+
+    this.hostingApiService.getLogs(this.server.serverId, this.lineCount).subscribe({
+      next: (response) => {
+        this.logs = response.logs;
+        this.message = response.message;
+        this.isLoading = false;
+      },
+      error: (err) => {
+        this.error = err.error || 'Failed to load logs';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  downloadLogs(): void {
+    const logContent = this.logs.join('\n');
+    const blob = new Blob([logContent], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${this.server.serverId}-logs.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  onOverlayClick(event: MouseEvent): void {
+    if ((event.target as HTMLElement).classList.contains('modal-overlay')) {
+      this.close.emit();
+    }
+  }
+
+  onClose(): void {
+    this.close.emit();
+  }
+}

--- a/packages/frontend/src/app/features/servers/components/server-management-card/server-management-card.component.html
+++ b/packages/frontend/src/app/features/servers/components/server-management-card/server-management-card.component.html
@@ -1,0 +1,101 @@
+<div class="server-card" [ngClass]="statusClass">
+  <div class="status-indicator"></div>
+
+  <div class="server-info">
+    <div class="server-header">
+      <div class="server-id">
+        <mat-icon [class]="statusClass">{{ statusIcon }}</mat-icon>
+        <span class="server-id-text">{{ server.serverId }}</span>
+      </div>
+    </div>
+
+    <h3 class="server-name">{{ server.serverName }}</h3>
+    <p class="server-description" *ngIf="server.description">{{ server.description }}</p>
+
+    <!-- Deploying State -->
+    <div class="deploy-progress" *ngIf="isDeploying">
+      <p class="deploy-message">{{ server.statusMessage || 'Deploying...' }}</p>
+      <mat-progress-bar mode="determinate" [value]="deployProgress"></mat-progress-bar>
+      <span class="progress-text">{{ deployProgress | number:'1.0-0' }}%</span>
+    </div>
+
+    <!-- Running/Stopped State -->
+    <ng-container *ngIf="!isDeploying">
+      <div class="server-endpoint">
+        <label>Endpoint:</label>
+        <code>{{ server.endpointUrl }}</code>
+        <button mat-icon-button (click)="copyEndpoint()" matTooltip="Copy endpoint URL" class="copy-btn">
+          <mat-icon>content_copy</mat-icon>
+        </button>
+      </div>
+
+      <div class="server-stats">
+        <span class="stat">
+          <mat-icon>{{ statusIcon }}</mat-icon>
+          <strong>{{ statusLabel }}</strong>
+        </span>
+        <span class="stat">
+          <mat-icon>analytics</mat-icon>
+          {{ server.requestCount | number }} requests
+        </span>
+        <span class="stat" *ngIf="server.lastRequestAt">
+          <mat-icon>schedule</mat-icon>
+          Last: {{ server.lastRequestAt | timeAgo }}
+        </span>
+      </div>
+
+      <div class="server-tools" *ngIf="server.tools && server.tools.length > 0">
+        <label>Tools:</label>
+        <div class="tools-list">
+          <span class="tool-tag" *ngFor="let tool of server.tools.slice(0, 5)">{{ tool.name }}</span>
+          <span class="tool-tag more" *ngIf="server.tools.length > 5">+{{ server.tools.length - 5 }} more</span>
+        </div>
+      </div>
+    </ng-container>
+  </div>
+
+  <div class="server-actions" *ngIf="!isDeploying">
+    <button
+      *ngIf="server.status === 'running'"
+      mat-button
+      (click)="onStop()"
+      class="action-btn"
+      matTooltip="Stop server">
+      <mat-icon>pause</mat-icon>
+      Stop
+    </button>
+    <button
+      *ngIf="server.status === 'stopped'"
+      mat-button
+      (click)="onStart()"
+      class="action-btn"
+      matTooltip="Start server">
+      <mat-icon>play_arrow</mat-icon>
+      Start
+    </button>
+    <button
+      mat-button
+      (click)="copyClaudeConfig()"
+      class="action-btn"
+      matTooltip="Copy Claude Desktop config">
+      <mat-icon>integration_instructions</mat-icon>
+      Config
+    </button>
+    <button
+      mat-button
+      (click)="onViewLogs()"
+      class="action-btn"
+      matTooltip="View logs">
+      <mat-icon>article</mat-icon>
+      Logs
+    </button>
+    <button
+      mat-button
+      (click)="onDelete()"
+      class="action-btn action-delete"
+      matTooltip="Delete server">
+      <mat-icon>delete</mat-icon>
+      Delete
+    </button>
+  </div>
+</div>

--- a/packages/frontend/src/app/features/servers/components/server-management-card/server-management-card.component.scss
+++ b/packages/frontend/src/app/features/servers/components/server-management-card/server-management-card.component.scss
@@ -1,0 +1,311 @@
+.server-card {
+  background: white;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  padding: 20px;
+  position: relative;
+  transition: all 0.2s ease;
+  overflow: hidden;
+
+  &:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    transform: translateY(-2px);
+  }
+
+  .status-indicator {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 4px;
+    height: 100%;
+    border-radius: 12px 0 0 12px;
+  }
+
+  &.status-running .status-indicator {
+    background-color: #4caf50;
+  }
+
+  &.status-stopped .status-indicator {
+    background-color: #f44336;
+  }
+
+  &.status-deploying .status-indicator {
+    background-color: #ff9800;
+  }
+
+  &.status-failed .status-indicator {
+    background-color: #c62828;
+  }
+
+  &.status-unknown .status-indicator {
+    background-color: #9e9e9e;
+  }
+}
+
+.server-info {
+  .server-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 8px;
+  }
+
+  .server-id {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+
+      &.status-running {
+        color: #4caf50;
+      }
+
+      &.status-stopped {
+        color: #f44336;
+      }
+
+      &.status-deploying {
+        color: #ff9800;
+      }
+
+      &.status-failed {
+        color: #c62828;
+      }
+    }
+
+    .server-id-text {
+      font-family: monospace;
+      font-size: 12px;
+      color: #6b6b6b;
+    }
+  }
+
+  .server-name {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1f1f1f;
+    margin: 0 0 4px 0;
+  }
+
+  .server-description {
+    font-size: 14px;
+    color: #6b6b6b;
+    margin: 0 0 16px 0;
+    line-height: 1.4;
+  }
+}
+
+.deploy-progress {
+  background: #fff8e1;
+  border-radius: 8px;
+  padding: 16px;
+  margin-top: 12px;
+
+  .deploy-message {
+    font-size: 14px;
+    color: #f57c00;
+    margin: 0 0 12px 0;
+  }
+
+  mat-progress-bar {
+    border-radius: 4px;
+    height: 8px;
+
+    ::ng-deep {
+      .mdc-linear-progress__buffer {
+        background-color: #ffe0b2;
+      }
+
+      .mdc-linear-progress__bar-inner {
+        border-color: #ff9800;
+      }
+    }
+  }
+
+  .progress-text {
+    display: block;
+    text-align: right;
+    font-size: 12px;
+    color: #f57c00;
+    margin-top: 4px;
+  }
+}
+
+.server-endpoint {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0;
+  padding: 12px;
+  background: #f5f5f5;
+  border-radius: 8px;
+
+  label {
+    font-size: 12px;
+    color: #6b6b6b;
+    font-weight: 500;
+  }
+
+  code {
+    flex: 1;
+    font-size: 13px;
+    color: #1f1f1f;
+    font-family: monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .copy-btn {
+    color: #6b6b6b;
+    width: 32px;
+    height: 32px;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover {
+      color: #1f1f1f;
+    }
+  }
+}
+
+.server-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 12px 0;
+
+  .stat {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: #6b6b6b;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+
+    strong {
+      color: #1f1f1f;
+    }
+  }
+}
+
+.server-tools {
+  margin: 12px 0;
+
+  label {
+    display: block;
+    font-size: 12px;
+    color: #6b6b6b;
+    font-weight: 500;
+    margin-bottom: 8px;
+  }
+
+  .tools-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .tool-tag {
+    background: #e8f5e9;
+    color: #2e7d32;
+    font-size: 12px;
+    padding: 4px 10px;
+    border-radius: 12px;
+    font-family: monospace;
+
+    &.more {
+      background: #f5f5f5;
+      color: #6b6b6b;
+    }
+  }
+}
+
+.server-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #e5e5e5;
+
+  .action-btn {
+    flex: 1;
+    min-width: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    font-size: 13px;
+    color: #6b6b6b;
+    border-radius: 8px;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover {
+      background: #f5f5f5;
+      color: #1f1f1f;
+    }
+
+    &.action-delete {
+      color: #c62828;
+
+      &:hover {
+        background: #ffebee;
+        color: #c62828;
+      }
+    }
+  }
+}
+
+// Responsive styles
+@media (max-width: 480px) {
+  .server-card {
+    padding: 16px;
+  }
+
+  .server-endpoint {
+    flex-wrap: wrap;
+
+    code {
+      width: 100%;
+      order: 1;
+      margin-top: 8px;
+    }
+  }
+
+  .server-stats {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .server-actions {
+    .action-btn {
+      min-width: 60px;
+      font-size: 12px;
+
+      mat-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+  }
+}

--- a/packages/frontend/src/app/features/servers/components/server-management-card/server-management-card.component.ts
+++ b/packages/frontend/src/app/features/servers/components/server-management-card/server-management-card.component.ts
@@ -1,0 +1,116 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+
+import { HostedServer, HostedServerStatus } from '../../../../core/services/hosting-api.service';
+import { TimeAgoPipe } from '../../../../shared/pipes/time-ago.pipe';
+
+@Component({
+  selector: 'mcp-server-management-card',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatButtonModule,
+    MatTooltipModule,
+    MatProgressBarModule,
+    TimeAgoPipe
+  ],
+  templateUrl: './server-management-card.component.html',
+  styleUrls: ['./server-management-card.component.scss']
+})
+export class ServerManagementCardComponent {
+  @Input() server!: HostedServer;
+  @Output() start = new EventEmitter<HostedServer>();
+  @Output() stop = new EventEmitter<HostedServer>();
+  @Output() delete = new EventEmitter<HostedServer>();
+  @Output() viewLogs = new EventEmitter<HostedServer>();
+
+  get isDeploying(): boolean {
+    const deployingStates: HostedServerStatus[] = ['pending', 'building', 'pushing', 'deploying'];
+    return deployingStates.includes(this.server.status);
+  }
+
+  get deployProgress(): number {
+    const stages: HostedServerStatus[] = ['pending', 'building', 'pushing', 'deploying', 'running'];
+    const index = stages.indexOf(this.server.status);
+    if (index === -1) return 0;
+    return ((index + 1) / stages.length) * 100;
+  }
+
+  get statusClass(): string {
+    switch (this.server.status) {
+      case 'running':
+        return 'status-running';
+      case 'stopped':
+        return 'status-stopped';
+      case 'failed':
+        return 'status-failed';
+      case 'pending':
+      case 'building':
+      case 'pushing':
+      case 'deploying':
+        return 'status-deploying';
+      default:
+        return 'status-unknown';
+    }
+  }
+
+  get statusIcon(): string {
+    switch (this.server.status) {
+      case 'running':
+        return 'check_circle';
+      case 'stopped':
+        return 'stop_circle';
+      case 'failed':
+        return 'error';
+      case 'pending':
+      case 'building':
+      case 'pushing':
+      case 'deploying':
+        return 'pending';
+      default:
+        return 'help';
+    }
+  }
+
+  get statusLabel(): string {
+    return this.server.status.charAt(0).toUpperCase() + this.server.status.slice(1);
+  }
+
+  copyEndpoint(): void {
+    navigator.clipboard.writeText(this.server.endpointUrl);
+  }
+
+  copyClaudeConfig(): void {
+    const serverSlug = this.server.serverName.toLowerCase().replace(/\s+/g, '-');
+    const config = {
+      mcpServers: {
+        [serverSlug]: {
+          command: 'mcp-connect',
+          args: [this.server.serverId]
+        }
+      }
+    };
+    navigator.clipboard.writeText(JSON.stringify(config, null, 2));
+  }
+
+  onStart(): void {
+    this.start.emit(this.server);
+  }
+
+  onStop(): void {
+    this.stop.emit(this.server);
+  }
+
+  onDelete(): void {
+    this.delete.emit(this.server);
+  }
+
+  onViewLogs(): void {
+    this.viewLogs.emit(this.server);
+  }
+}

--- a/packages/frontend/src/app/features/servers/servers.component.html
+++ b/packages/frontend/src/app/features/servers/servers.component.html
@@ -1,0 +1,70 @@
+<div class="servers-page">
+  <header class="servers-header">
+    <h1>My Hosted Servers</h1>
+    <div class="header-actions">
+      <button mat-icon-button (click)="refreshServers()" class="refresh-button" title="Refresh">
+        <mat-icon>refresh</mat-icon>
+      </button>
+      <button mat-raised-button routerLink="/chat" class="btn-primary">
+        <mat-icon>add</mat-icon>
+        New Server
+      </button>
+    </div>
+  </header>
+
+  <!-- Loading State -->
+  <div *ngIf="isLoading" class="loading-state">
+    <mat-spinner diameter="40"></mat-spinner>
+    <p>Loading servers...</p>
+  </div>
+
+  <!-- Error State -->
+  <div *ngIf="error && !isLoading" class="error-state">
+    <mat-icon>error_outline</mat-icon>
+    <p>{{ error }}</p>
+    <button mat-button (click)="refreshServers()">Try Again</button>
+  </div>
+
+  <!-- Empty State -->
+  <div *ngIf="!isLoading && !error && servers.length === 0" class="empty-state">
+    <mat-icon class="empty-icon">cloud_off</mat-icon>
+    <h2>No Hosted Servers Yet</h2>
+    <p>You haven't deployed any MCP servers to the cloud.</p>
+    <p>Create a new server through the chat interface and deploy it to get started.</p>
+    <button mat-raised-button routerLink="/chat" class="btn-primary">
+      <mat-icon>add</mat-icon>
+      Create Your First Server
+    </button>
+  </div>
+
+  <!-- Servers List -->
+  <div *ngIf="!isLoading && !error && servers.length > 0" class="servers-list">
+    <mcp-server-management-card
+      *ngFor="let server of servers"
+      [server]="server"
+      (start)="startServer($event)"
+      (stop)="stopServer($event)"
+      (delete)="openDeleteConfirmation($event)"
+      (viewLogs)="openLogs($event)">
+    </mcp-server-management-card>
+  </div>
+
+  <!-- Logs Modal -->
+  <mcp-logs-modal
+    *ngIf="selectedServerForLogs"
+    [server]="selectedServerForLogs"
+    (close)="closeLogs()">
+  </mcp-logs-modal>
+
+  <!-- Delete Confirmation Modal -->
+  <mcp-confirm-modal
+    *ngIf="serverToDelete"
+    title="Delete Server"
+    [message]="'Are you sure you want to delete \'' + serverToDelete.serverName + '\'? This action cannot be undone and will permanently remove the server and all its data.'"
+    confirmText="Delete"
+    cancelText="Cancel"
+    [isDanger]="true"
+    (confirm)="confirmDelete()"
+    (cancel)="cancelDelete()">
+  </mcp-confirm-modal>
+</div>

--- a/packages/frontend/src/app/features/servers/servers.component.scss
+++ b/packages/frontend/src/app/features/servers/servers.component.scss
@@ -1,0 +1,166 @@
+.servers-page {
+  padding: 24px;
+  max-width: 1400px;
+  margin: 0 auto;
+  min-height: calc(100vh - 64px);
+}
+
+.servers-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #e5e5e5;
+
+  h1 {
+    font-size: 24px;
+    font-weight: 600;
+    color: #1f1f1f;
+    margin: 0;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .refresh-button {
+    color: #6b6b6b;
+
+    &:hover {
+      color: #1f1f1f;
+    }
+  }
+
+  .btn-primary {
+    background-color: #2d2d2d;
+    color: white;
+    border-radius: 8px;
+    padding: 8px 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+    }
+
+    &:hover {
+      background-color: #1a1a1a;
+    }
+  }
+}
+
+.loading-state,
+.error-state,
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 24px;
+  text-align: center;
+
+  mat-icon {
+    font-size: 64px;
+    width: 64px;
+    height: 64px;
+    color: #6b6b6b;
+    margin-bottom: 16px;
+  }
+
+  p {
+    color: #6b6b6b;
+    font-size: 14px;
+    margin: 4px 0;
+    max-width: 400px;
+  }
+}
+
+.loading-state {
+  mat-spinner {
+    margin-bottom: 16px;
+  }
+}
+
+.error-state {
+  mat-icon {
+    color: #c62828;
+  }
+
+  button {
+    margin-top: 16px;
+    color: #2d2d2d;
+  }
+}
+
+.empty-state {
+  .empty-icon {
+    font-size: 80px;
+    width: 80px;
+    height: 80px;
+    color: #e5e5e5;
+  }
+
+  h2 {
+    font-size: 20px;
+    font-weight: 600;
+    color: #1f1f1f;
+    margin: 0 0 8px 0;
+  }
+
+  .btn-primary {
+    margin-top: 24px;
+    background-color: #2d2d2d;
+    color: white;
+    border-radius: 8px;
+    padding: 12px 24px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    &:hover {
+      background-color: #1a1a1a;
+    }
+  }
+}
+
+.servers-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  gap: 20px;
+}
+
+// Responsive styles
+@media (max-width: 768px) {
+  .servers-page {
+    padding: 16px;
+  }
+
+  .servers-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+
+    .header-actions {
+      width: 100%;
+      justify-content: space-between;
+    }
+  }
+
+  .servers-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .servers-header {
+    h1 {
+      font-size: 20px;
+    }
+  }
+}

--- a/packages/frontend/src/app/features/servers/servers.component.ts
+++ b/packages/frontend/src/app/features/servers/servers.component.ts
@@ -1,0 +1,142 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Subject, interval } from 'rxjs';
+import { takeUntil, startWith, switchMap } from 'rxjs/operators';
+
+import { HostingApiService, HostedServer } from '../../core/services/hosting-api.service';
+import { ServerManagementCardComponent } from './components/server-management-card/server-management-card.component';
+import { LogsModalComponent } from './components/logs-modal/logs-modal.component';
+import { ConfirmModalComponent } from './components/confirm-modal/confirm-modal.component';
+
+@Component({
+  selector: 'mcp-servers',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    ServerManagementCardComponent,
+    LogsModalComponent,
+    ConfirmModalComponent
+  ],
+  templateUrl: './servers.component.html',
+  styleUrls: ['./servers.component.scss']
+})
+export class ServersComponent implements OnInit, OnDestroy {
+  servers: HostedServer[] = [];
+  isLoading = true;
+  error: string | null = null;
+
+  selectedServerForLogs: HostedServer | null = null;
+  serverToDelete: HostedServer | null = null;
+
+  private destroy$ = new Subject<void>();
+  private refreshInterval = 30000; // 30 seconds
+
+  constructor(private hostingApiService: HostingApiService) {}
+
+  ngOnInit(): void {
+    this.loadServers();
+    this.startAutoRefresh();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private loadServers(): void {
+    this.isLoading = true;
+    this.error = null;
+
+    this.hostingApiService.listServers().subscribe({
+      next: (response) => {
+        this.servers = response.servers;
+        this.isLoading = false;
+      },
+      error: (err) => {
+        this.error = err.error || 'Failed to load servers';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  private startAutoRefresh(): void {
+    interval(this.refreshInterval)
+      .pipe(
+        takeUntil(this.destroy$),
+        switchMap(() => this.hostingApiService.listServers())
+      )
+      .subscribe({
+        next: (response) => {
+          this.servers = response.servers;
+        },
+        error: (err) => {
+          console.error('Auto-refresh failed:', err);
+        }
+      });
+  }
+
+  refreshServers(): void {
+    this.loadServers();
+  }
+
+  startServer(server: HostedServer): void {
+    this.hostingApiService.startServer(server.serverId).subscribe({
+      next: () => {
+        this.loadServers();
+      },
+      error: (err) => {
+        console.error('Failed to start server:', err);
+      }
+    });
+  }
+
+  stopServer(server: HostedServer): void {
+    this.hostingApiService.stopServer(server.serverId).subscribe({
+      next: () => {
+        this.loadServers();
+      },
+      error: (err) => {
+        console.error('Failed to stop server:', err);
+      }
+    });
+  }
+
+  openDeleteConfirmation(server: HostedServer): void {
+    this.serverToDelete = server;
+  }
+
+  confirmDelete(): void {
+    if (!this.serverToDelete) return;
+
+    this.hostingApiService.deleteServer(this.serverToDelete.serverId).subscribe({
+      next: () => {
+        this.serverToDelete = null;
+        this.loadServers();
+      },
+      error: (err) => {
+        console.error('Failed to delete server:', err);
+        this.serverToDelete = null;
+      }
+    });
+  }
+
+  cancelDelete(): void {
+    this.serverToDelete = null;
+  }
+
+  openLogs(server: HostedServer): void {
+    this.selectedServerForLogs = server;
+  }
+
+  closeLogs(): void {
+    this.selectedServerForLogs = null;
+  }
+}

--- a/packages/frontend/src/app/features/servers/servers.module.ts
+++ b/packages/frontend/src/app/features/servers/servers.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ServersComponent } from './servers.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: ServersComponent
+  }
+];
+
+@NgModule({
+  imports: [
+    ServersComponent,
+    RouterModule.forChild(routes)
+  ]
+})
+export class ServersModule { }

--- a/packages/frontend/src/app/shared/components/top-nav/top-nav.component.html
+++ b/packages/frontend/src/app/shared/components/top-nav/top-nav.component.html
@@ -12,14 +12,21 @@
       </button>
     </div>
 
-    <!-- Center Section: Explore Link -->
+    <!-- Center Section: Navigation Links -->
     <div class="nav-center">
       <button
         mat-button
         routerLink="/explore"
         routerLinkActive="active"
-        class="explore-button">
+        class="nav-button">
         Explore
+      </button>
+      <button
+        mat-button
+        routerLink="/servers"
+        routerLinkActive="active"
+        class="nav-button">
+        My Servers
       </button>
     </div>
 

--- a/packages/frontend/src/app/shared/components/top-nav/top-nav.component.scss
+++ b/packages/frontend/src/app/shared/components/top-nav/top-nav.component.scss
@@ -35,8 +35,9 @@
   transform: translateX(-50%);
   display: flex;
   align-items: center;
+  gap: 8px;
 
-  .explore-button {
+  .nav-button {
     font-size: 14px;
     font-weight: 500;
     color: #6b6b6b;

--- a/packages/frontend/src/app/shared/pipes/time-ago.pipe.ts
+++ b/packages/frontend/src/app/shared/pipes/time-ago.pipe.ts
@@ -1,0 +1,41 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'timeAgo',
+  standalone: true
+})
+export class TimeAgoPipe implements PipeTransform {
+  transform(value: Date | string | undefined | null): string {
+    if (!value) {
+      return 'Never';
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    const now = new Date();
+    const seconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+
+    if (seconds < 0) {
+      return 'Just now';
+    }
+
+    const intervals: { [key: string]: number } = {
+      year: 31536000,
+      month: 2592000,
+      week: 604800,
+      day: 86400,
+      hour: 3600,
+      minute: 60,
+      second: 1
+    };
+
+    for (const [unit, secondsInUnit] of Object.entries(intervals)) {
+      const interval = Math.floor(seconds / secondsInUnit);
+      if (interval >= 1) {
+        const suffix = interval === 1 ? '' : 's';
+        return `${interval} ${unit}${suffix} ago`;
+      }
+    }
+
+    return 'Just now';
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `/servers` route with a comprehensive dashboard for managing hosted MCP servers.

- **ServersComponent**: Main dashboard page displaying all user's hosted servers with loading, error, and empty states
- **ServerManagementCardComponent**: Individual server cards showing status, endpoint, request stats, and action buttons
- **LogsModalComponent**: Modal to view server logs with line count selector (50/100/500) and download option
- **ConfirmModalComponent**: Reusable confirmation dialog for destructive actions like deletion
- **TimeAgoPipe**: Formats relative time display (e.g., "2 minutes ago")

## Features

- **Server Management**: Start/Stop/Delete servers directly from the dashboard
- **Quick Actions**: Copy endpoint URL and Claude Desktop config JSON to clipboard
- **Status Indicators**: Visual status badges (green=running, red=stopped, yellow=deploying)
- **Deploy Progress**: Progress bar for servers being deployed
- **Auto-refresh**: Dashboard refreshes every 30 seconds for status updates
- **Responsive Design**: Mobile-friendly layout

## Changes

- Added `/servers` route with lazy loading to `app-routing.module.ts`
- Added "My Servers" link in top navigation bar
- Added `getLogs()` method to `HostingApiService`
- Created 5 new components under `features/servers/`
- Created `TimeAgoPipe` in shared pipes

## Test plan

- [ ] Navigate to /servers route
- [ ] Verify empty state displays when no servers exist
- [ ] Verify server cards display with correct status colors
- [ ] Test Start/Stop button toggles correctly
- [ ] Test Delete button shows confirmation modal
- [ ] Test Copy Endpoint and Copy Config buttons
- [ ] Test Logs modal opens and shows logs
- [ ] Verify auto-refresh updates server status
- [ ] Test responsive layout on mobile viewport

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)