### PR TITLE
feat(testing): Add Playwright E2E configuration

### DIFF
--- a/packages/frontend/e2e/helpers/global-setup.ts
+++ b/packages/frontend/e2e/helpers/global-setup.ts
@@ -1,0 +1,33 @@
+import { FullConfig } from '@playwright/test';
+
+/**
+ * Global setup function for E2E tests
+ * Runs once before all E2E tests start
+ */
+async function globalSetup(config: FullConfig): Promise<void> {
+  console.log('\n=== E2E Test Suite Global Setup ===');
+  console.log(`Base URL: ${config.projects[0]?.use?.baseURL || 'not set'}`);
+  console.log(`Workers: ${config.workers}`);
+  console.log(`Timeout: ${config.globalTimeout}ms`);
+
+  // Verify environment variables
+  const requiredEnvVars = ['FRONTEND_URL', 'BACKEND_URL'];
+  const missingVars = requiredEnvVars.filter((v) => !process.env[v]);
+
+  if (missingVars.length > 0) {
+    console.log(
+      `Warning: Missing environment variables: ${missingVars.join(', ')}`
+    );
+    console.log('Using default localhost URLs');
+  }
+
+  // Set default environment variables if not set
+  process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:4200';
+  process.env.BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3000';
+
+  console.log(`Frontend URL: ${process.env.FRONTEND_URL}`);
+  console.log(`Backend URL: ${process.env.BACKEND_URL}`);
+  console.log('=== Setup Complete ===\n');
+}
+
+export default globalSetup;

--- a/packages/frontend/e2e/helpers/global-teardown.ts
+++ b/packages/frontend/e2e/helpers/global-teardown.ts
@@ -1,0 +1,21 @@
+import { FullConfig } from '@playwright/test';
+
+/**
+ * Global teardown function for E2E tests
+ * Runs once after all E2E tests complete
+ */
+async function globalTeardown(config: FullConfig): Promise<void> {
+  console.log('\n=== E2E Test Suite Global Teardown ===');
+  console.log('Cleaning up test artifacts...');
+
+  // Add any cleanup logic here
+  // Examples:
+  // - Clean up test databases
+  // - Remove temporary files
+  // - Reset external service states
+
+  console.log('Teardown complete');
+  console.log('=== Teardown Complete ===\n');
+}
+
+export default globalTeardown;

--- a/packages/frontend/e2e/tests/e2e/.gitkeep
+++ b/packages/frontend/e2e/tests/e2e/.gitkeep
@@ -1,0 +1,7 @@
+# E2E Test Directory
+# Place end-to-end tests here that require:
+# - Real Claude API integration
+# - KinD deployment validation
+# - Full system integration testing
+#
+# Run with: npm run e2e:full

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -22,6 +22,10 @@
     "e2e:mobile": "playwright test --project='Mobile Chrome' --project='Mobile Safari'",
     "e2e:report": "playwright show-report e2e/playwright-report",
     "e2e:install": "playwright install --with-deps",
+    "e2e:full": "playwright test --config=playwright.e2e.config.ts",
+    "e2e:full:headed": "playwright test --config=playwright.e2e.config.ts --headed",
+    "e2e:full:debug": "playwright test --config=playwright.e2e.config.ts --debug",
+    "e2e:full:report": "playwright show-report e2e/playwright-report-e2e",
     "serve:dev": "ng serve --configuration development --host 0.0.0.0 --port 4200",
     "analyze": "npx webpack-bundle-analyzer dist/main.js"
   },

--- a/packages/frontend/playwright.e2e.config.ts
+++ b/packages/frontend/playwright.e2e.config.ts
@@ -1,0 +1,96 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E Test Configuration for MCP Everything
+ *
+ * This configuration is designed for end-to-end tests that require:
+ * - Real Claude API integration
+ * - KinD deployment validation
+ * - Full system integration testing
+ *
+ * Usage: npx playwright test --config=playwright.e2e.config.ts
+ */
+export default defineConfig({
+  testDir: './e2e/tests/e2e',
+
+  /* 5 minutes per test - E2E tests with AI can be slow */
+  timeout: 300000,
+
+  /* Sequential execution - avoid resource conflicts */
+  fullyParallel: false,
+
+  /* Fail the build on CI if you accidentally left test.only in the source code */
+  forbidOnly: !!process.env.CI,
+
+  /* One retry for flaky network issues */
+  retries: 1,
+
+  /* Single worker to avoid resource conflicts */
+  workers: 1,
+
+  /* Reporter configuration */
+  reporter: [
+    ['html', { outputFolder: 'e2e/playwright-report-e2e' }],
+    ['json', { outputFile: 'e2e/test-results-e2e.json' }],
+    ['list'],
+  ],
+
+  /* Global setup and teardown */
+  globalSetup: './e2e/helpers/global-setup.ts',
+  globalTeardown: './e2e/helpers/global-teardown.ts',
+
+  /* Shared settings for all projects */
+  use: {
+    /* Base URL for frontend */
+    baseURL: process.env.FRONTEND_URL || 'http://localhost:4200',
+
+    /* Always capture traces for debugging */
+    trace: 'on',
+
+    /* Always capture screenshots */
+    screenshot: 'on',
+
+    /* Always record videos */
+    video: 'on',
+
+    /* 30 seconds per action - chat responses can be slow */
+    actionTimeout: 30000,
+
+    /* Desktop viewport */
+    viewport: { width: 1280, height: 720 },
+  },
+
+  /* 60 seconds for assertions */
+  expect: {
+    timeout: 60000,
+  },
+
+  /* Chromium only for E2E - faster and more reliable */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  /* Configure web servers for both frontend and backend */
+  webServer: [
+    {
+      command: 'npm run start',
+      port: 4200,
+      timeout: 120000,
+      reuseExistingServer: true,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+    {
+      command: 'npm run start:dev',
+      port: 3000,
+      timeout: 120000,
+      reuseExistingServer: true,
+      cwd: '../backend',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Create dedicated Playwright E2E configuration with extended timeouts for real AI/K8s testing
- Add global setup/teardown hooks for environment verification
- Add npm scripts for running E2E tests

## Changes
- `packages/frontend/playwright.e2e.config.ts` - New E2E config with:
  - 5 minute test timeout
  - 30 second action timeout
  - 60 second expect timeout
  - Sequential execution (workers: 1)
  - Always capture traces, videos, screenshots
  - Both frontend (4200) and backend (3000) web servers
  - Chromium-only project

- `packages/frontend/e2e/helpers/global-setup.ts` - Pre-test environment verification
- `packages/frontend/e2e/helpers/global-teardown.ts` - Post-test cleanup
- `packages/frontend/e2e/tests/e2e/` - Directory for E2E-specific tests
- `packages/frontend/package.json` - New npm scripts:
  - `e2e:full` - Run E2E tests
  - `e2e:full:headed` - Headed mode
  - `e2e:full:debug` - Debug mode
  - `e2e:full:report` - View reports

## Test plan
- [ ] Run `npm run e2e:full` to verify config loads correctly
- [ ] Verify global setup/teardown logs appear
- [ ] Confirm both web servers are configured correctly

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)