### PR TITLE
feat(e2e): Add global setup/teardown with infrastructure validation (#62)

### DIFF
--- a/packages/frontend/e2e/helpers/environment-check.ts
+++ b/packages/frontend/e2e/helpers/environment-check.ts
@@ -1,0 +1,112 @@
+import { KindClusterFixture } from '../fixtures/kind-cluster';
+import { E2EBackendFixture } from '../fixtures/e2e-backend';
+
+export interface EnvironmentCheck {
+  name: string;
+  passed: boolean;
+  message: string;
+  fix?: string;
+}
+
+export interface EnvironmentStatus {
+  ready: boolean;
+  checks: EnvironmentCheck[];
+}
+
+/**
+ * Check all E2E environment requirements and return status
+ */
+export async function checkE2EEnvironment(): Promise<EnvironmentStatus> {
+  const kindCluster = new KindClusterFixture();
+  const backend = new E2EBackendFixture();
+  const checks: EnvironmentCheck[] = [];
+
+  // Check 1: KinD Cluster
+  const clusterRunning = await kindCluster.isClusterRunning();
+  checks.push({
+    name: 'KinD Cluster',
+    passed: clusterRunning,
+    message: clusterRunning
+      ? 'KinD cluster is running'
+      : 'KinD cluster "mcp-local" is not running',
+    fix: clusterRunning ? undefined : './scripts/kind/setup.sh',
+  });
+
+  // Check 2: Docker Registry
+  const registryRunning = await kindCluster.isRegistryRunning();
+  checks.push({
+    name: 'Docker Registry',
+    passed: registryRunning,
+    message: registryRunning
+      ? 'Local registry is running'
+      : 'Local Docker registry is not running',
+    fix: registryRunning ? undefined : './scripts/kind/setup.sh',
+  });
+
+  // Check 3: Ingress Controller
+  const ingressReady = await kindCluster.isIngressReady();
+  checks.push({
+    name: 'Ingress Controller',
+    passed: ingressReady,
+    message: ingressReady
+      ? 'Ingress controller is ready'
+      : 'Nginx ingress controller is not ready',
+    fix: ingressReady ? undefined : './scripts/kind/setup.sh',
+  });
+
+  // Check 4: Backend Health
+  const backendReady = await backend.isReady();
+  checks.push({
+    name: 'Backend API',
+    passed: backendReady,
+    message: backendReady
+      ? 'Backend API is healthy'
+      : 'Backend API is not responding at http://localhost:3000',
+    fix: backendReady ? undefined : 'npm run dev:backend',
+  });
+
+  // Check 5: Claude API Key
+  const apiKeySet = !!process.env.ANTHROPIC_API_KEY;
+  checks.push({
+    name: 'Claude API Key',
+    passed: apiKeySet,
+    message: apiKeySet
+      ? 'Claude API key is configured'
+      : 'ANTHROPIC_API_KEY environment variable is not set',
+    fix: apiKeySet ? undefined : 'export ANTHROPIC_API_KEY=your-key',
+  });
+
+  // Check 6: Namespace
+  const namespaceExists = await kindCluster.isNamespaceExists();
+  checks.push({
+    name: 'K8s Namespace',
+    passed: namespaceExists,
+    message: namespaceExists
+      ? 'mcp-servers namespace exists'
+      : 'mcp-servers namespace does not exist',
+    fix: namespaceExists ? undefined : './scripts/kind/setup.sh',
+  });
+
+  const ready = checks.every((c) => c.passed);
+
+  return { ready, checks };
+}
+
+/**
+ * Require E2E environment to be ready, throw if not
+ * Can be used by individual tests to skip gracefully
+ */
+export async function requireE2EEnvironment(): Promise<void> {
+  const status = await checkE2EEnvironment();
+  if (!status.ready) {
+    const failedChecks = status.checks.filter((c) => !c.passed);
+    const errorLines = failedChecks.map((c) => {
+      let line = `- ${c.message}`;
+      if (c.fix) {
+        line += `\n    Fix: ${c.fix}`;
+      }
+      return line;
+    });
+    throw new Error(`E2E environment not ready:\n${errorLines.join('\n')}`);
+  }
+}

--- a/packages/frontend/e2e/helpers/global-setup.ts
+++ b/packages/frontend/e2e/helpers/global-setup.ts
@@ -1,33 +1,88 @@
 import { FullConfig } from '@playwright/test';
+import { KindClusterFixture } from '../fixtures/kind-cluster';
+import { E2EBackendFixture } from '../fixtures/e2e-backend';
 
 /**
  * Global setup function for E2E tests
- * Runs once before all E2E tests start
+ * Validates all infrastructure requirements before tests run
  */
 async function globalSetup(config: FullConfig): Promise<void> {
-  console.log('\n=== E2E Test Suite Global Setup ===');
-  console.log(`Base URL: ${config.projects[0]?.use?.baseURL || 'not set'}`);
-  console.log(`Workers: ${config.workers}`);
-  console.log(`Timeout: ${config.globalTimeout}ms`);
+  console.log('\n🚀 E2E Test Suite - Global Setup\n');
+  console.log('='.repeat(50));
 
-  // Verify environment variables
-  const requiredEnvVars = ['FRONTEND_URL', 'BACKEND_URL'];
-  const missingVars = requiredEnvVars.filter((v) => !process.env[v]);
+  const issues: string[] = [];
+  const kindCluster = new KindClusterFixture();
+  const backend = new E2EBackendFixture();
 
-  if (missingVars.length > 0) {
-    console.log(
-      `Warning: Missing environment variables: ${missingVars.join(', ')}`
+  // Check 1: KinD Cluster
+  console.log('Checking KinD cluster...');
+  if (!(await kindCluster.isClusterRunning())) {
+    issues.push(
+      'KinD cluster "mcp-local" is not running. Run: ./scripts/kind/setup.sh'
     );
-    console.log('Using default localhost URLs');
+  } else {
+    console.log('  ✓ KinD cluster is running');
   }
 
-  // Set default environment variables if not set
+  // Check 2: Docker Registry
+  console.log('Checking local registry...');
+  if (!(await kindCluster.isRegistryRunning())) {
+    issues.push(
+      'Local Docker registry is not running. Run: ./scripts/kind/setup.sh'
+    );
+  } else {
+    console.log('  ✓ Local registry is running');
+  }
+
+  // Check 3: Ingress Controller
+  console.log('Checking ingress controller...');
+  if (!(await kindCluster.isIngressReady())) {
+    issues.push('Nginx ingress controller is not ready');
+  } else {
+    console.log('  ✓ Ingress controller is ready');
+  }
+
+  // Check 4: Backend Health
+  console.log('Checking backend API...');
+  if (!(await backend.isReady())) {
+    issues.push(
+      'Backend API is not responding at http://localhost:3000. Run: npm run dev:backend'
+    );
+  } else {
+    console.log('  ✓ Backend API is healthy');
+  }
+
+  // Check 5: Claude API Key
+  console.log('Checking Claude API configuration...');
+  if (!process.env.ANTHROPIC_API_KEY) {
+    issues.push('ANTHROPIC_API_KEY environment variable is not set');
+  } else {
+    console.log('  ✓ Claude API key is configured');
+  }
+
+  // Check 6: Namespace
+  console.log('Checking mcp-servers namespace...');
+  if (!(await kindCluster.isNamespaceExists())) {
+    issues.push('mcp-servers namespace does not exist');
+  } else {
+    console.log('  ✓ mcp-servers namespace exists');
+  }
+
+  console.log('='.repeat(50));
+
+  // Set default environment variables
   process.env.FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:4200';
   process.env.BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3000';
 
-  console.log(`Frontend URL: ${process.env.FRONTEND_URL}`);
-  console.log(`Backend URL: ${process.env.BACKEND_URL}`);
-  console.log('=== Setup Complete ===\n');
+  if (issues.length > 0) {
+    console.log('\n❌ E2E Setup Failed!\n');
+    console.log('Issues found:');
+    issues.forEach((issue, i) => console.log(`  ${i + 1}. ${issue}`));
+    console.log('\nPlease fix the above issues and try again.\n');
+    throw new Error(`E2E setup failed: ${issues.length} issues found`);
+  }
+
+  console.log('\n✅ E2E Setup Complete - All checks passed!\n');
 }
 
 export default globalSetup;


### PR DESCRIPTION
## Summary
- Enhanced global-setup.ts to validate all E2E infrastructure before tests run
- Enhanced global-teardown.ts to clean up test resources after tests complete
- Created environment-check.ts reusable utility for tests to check environment

## Infrastructure Checks (global-setup)
1. KinD cluster running
2. Docker registry running
3. Nginx ingress controller ready
4. Backend API healthy
5. Claude API key configured
6. mcp-servers namespace exists

## Cleanup (global-teardown)
- Lists all deployed servers
- Filters for test prefixes (`test-*`, `e2e-*`, `*-test-*`)
- Safely cleans up test servers only

## Reusable Utility (environment-check)
- `checkE2EEnvironment()` - returns status object with all checks
- `requireE2EEnvironment()` - throws if environment not ready (for use in tests)

## Test plan
- [ ] Run `npx playwright test --config playwright.e2e.config.ts` without infrastructure to verify setup fails with clear messages
- [ ] Run with infrastructure to verify setup passes
- [ ] Create test servers and verify teardown cleans them up

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)