### PR TITLE
fix(backend): Add missing nanoid dependency

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -58,6 +58,7 @@
     "js-yaml": "^4.1.0",
     "langchain": "^0.3.35",
     "libsodium-wrappers": "^0.7.15",
+    "nanoid": "^5.0.9",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.11.3",


### PR DESCRIPTION
## Summary
- Adds missing `nanoid` dependency to `packages/backend/package.json`
- Fixes backend build failure caused by unresolved import in `hosting.service.ts:9`

## Bug Details
**Layer**: 2 (Backend Standalone)
**Severity**: Critical (blocks all backend testing)

The `hosting.service.ts` file imports `nanoid` for generating unique IDs, but the package was never added to the dependencies list. This caused TypeScript to fail compilation with:
```
Cannot find module 'nanoid' or its corresponding type declarations.
```

## Test plan
- [x] `npm install` succeeds
- [x] `npm run build` succeeds (backend compiles without errors)

## Related Issues
- Fixes bug tracked in #86 (Master Bug Tracker)
- Related to #88 (Layer 2: Backend Standalone Validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)