### PR TITLE
feat(frontend): Add standalone validation tests (#89)

### DIFF
--- a/packages/frontend/e2e/page-objects/top-nav.page.ts
+++ b/packages/frontend/e2e/page-objects/top-nav.page.ts
@@ -17,9 +17,10 @@ export class TopNavPage extends BasePage {
 
     this.topNav = page.locator('.top-nav');
     this.hamburgerButton = page.locator('.hamburger-button');
-    this.exploreButton = page.locator('.explore-button');
+    // Use routerLink attribute for more reliable selection
+    this.exploreButton = page.locator('button[routerLink="/explore"], .nav-button:has-text("Explore")');
     this.documentationButton = page.locator('.nav-icon-button').filter({ has: page.locator('mat-icon:has-text("menu_book")') });
-    this.accountButton = page.locator('.nav-icon-button').filter({ has: page.locator('mat-icon:has-text("account_circle")') });
+    this.accountButton = page.locator('button[routerLink="/account"], .nav-icon-button:has(mat-icon:has-text("account_circle"))');
   }
 
   /**

--- a/packages/frontend/e2e/tests/standalone-validation.spec.ts
+++ b/packages/frontend/e2e/tests/standalone-validation.spec.ts
@@ -1,0 +1,639 @@
+import { test, expect } from '@playwright/test';
+import { ChatPage } from '../page-objects/chat.page';
+import { SidebarPage } from '../page-objects/sidebar.page';
+import { TopNavPage } from '../page-objects/top-nav.page';
+
+/**
+ * Standalone Frontend Validation Tests
+ * Per Issue #89 - Layer 3: Frontend Standalone Validation
+ *
+ * These tests validate the Angular frontend builds, serves, and renders
+ * correctly in the browser without backend dependencies.
+ */
+
+test.describe('Frontend Standalone Validation', () => {
+  let chatPage: ChatPage;
+  let sidebarPage: SidebarPage;
+  let topNavPage: TopNavPage;
+
+  // Collect console errors during test
+  let consoleErrors: string[] = [];
+  let networkErrors: { url: string; status: number }[] = [];
+
+  /**
+   * Close any error dialogs/snackbars that appear due to missing backend
+   * This is expected in standalone mode
+   */
+  async function dismissNetworkErrorDialog(page: import('@playwright/test').Page) {
+    // Give a moment for any toasts/snackbars to appear
+    await page.waitForTimeout(500);
+
+    // Check if snackbar exists
+    const snackbar = page.locator('mat-snack-bar-container, .mat-mdc-snack-bar-container');
+    const snackbarExists = await snackbar.isVisible({ timeout: 1000 }).catch(() => false);
+
+    if (snackbarExists) {
+      // Try to close snackbar using the action button inside the snackbar
+      const snackbarClose = snackbar.locator('button');
+      if (await snackbarClose.isVisible({ timeout: 500 }).catch(() => false)) {
+        await snackbarClose.click({ force: true });
+        await page.waitForTimeout(500);
+        return;
+      }
+
+      // Wait for snackbar to auto-dismiss if no button
+      await snackbar.waitFor({ state: 'hidden', timeout: 6000 }).catch(() => {});
+      return;
+    }
+
+    // Check for any error dialog (not sidebar)
+    const errorDialog = page.locator('.error-dialog, [role="alertdialog"], .cdk-overlay-pane:has(.error)');
+    if (await errorDialog.isVisible({ timeout: 500 }).catch(() => false)) {
+      const dialogClose = errorDialog.locator('button:has-text("Close"), button:has-text("OK")');
+      if (await dialogClose.isVisible({ timeout: 500 }).catch(() => false)) {
+        await dialogClose.click({ force: true });
+        await page.waitForTimeout(300);
+      }
+    }
+  }
+
+  test.beforeEach(async ({ page }) => {
+    // Reset error collectors
+    consoleErrors = [];
+    networkErrors = [];
+
+    // Listen for console errors
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        consoleErrors.push(msg.text());
+      }
+    });
+
+    // Listen for network failures
+    page.on('response', (response) => {
+      if (response.status() >= 400) {
+        networkErrors.push({
+          url: response.url(),
+          status: response.status(),
+        });
+      }
+    });
+
+    chatPage = new ChatPage(page);
+    sidebarPage = new SidebarPage(page);
+    topNavPage = new TopNavPage(page);
+  });
+
+  // ============================================================
+  // 3.3 Access in Browser
+  // ============================================================
+  test.describe('3.3 Access in Browser', () => {
+    test('should load page (not blank/white screen)', async ({ page }) => {
+      await page.goto('/');
+
+      // Wait for Angular to bootstrap
+      await page.waitForLoadState('networkidle');
+
+      // Check that we have actual content (before any interactions)
+      const bodyContent = await page.locator('body').textContent();
+      expect(bodyContent?.length).toBeGreaterThan(0);
+
+      // Check that main content area is visible (not blank)
+      // Use multiple possible selectors for robustness
+      const contentArea = page.locator('main, .main-content, .chat-container, .welcome-screen').first();
+      await expect(contentArea).toBeVisible({ timeout: 15000 });
+
+      // Dismiss any network error dialog (expected when backend is not running)
+      await dismissNetworkErrorDialog(page);
+
+      // Verify the page still has content after dismissing dialogs
+      const finalContent = await page.locator('body').textContent();
+      expect(finalContent?.length).toBeGreaterThan(100); // Should have substantial content
+    });
+
+    test('should redirect to /chat (or intended route)', async ({ page }) => {
+      await page.goto('/');
+
+      // Should redirect to /chat
+      await page.waitForURL(/\/chat/);
+      expect(page.url()).toContain('/chat');
+    });
+
+    test('should not show infinite loading spinner', async ({ page }) => {
+      await page.goto('/chat');
+
+      // Wait for initial load
+      await page.waitForLoadState('networkidle');
+
+      // Check that there's no persistent spinner
+      const spinner = page.locator('mat-spinner, .loading-spinner, [role="progressbar"]');
+
+      // Give a short wait for any temporary spinners to resolve
+      await page.waitForTimeout(2000);
+
+      // Either spinner doesn't exist, or it should disappear
+      const spinnerVisible = await spinner.isVisible().catch(() => false);
+      if (spinnerVisible) {
+        // If spinner is visible, wait for it to disappear (with reasonable timeout)
+        await expect(spinner).toBeHidden({ timeout: 10000 });
+      }
+    });
+  });
+
+  // ============================================================
+  // 3.4 Browser Console Check
+  // ============================================================
+  test.describe('3.4 Browser Console Check', () => {
+    test('should have no red errors on page load', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Filter out known acceptable errors (e.g., missing backend, analytics)
+      const criticalErrors = consoleErrors.filter((error) => {
+        const lowerError = error.toLowerCase();
+        // Ignore backend connection errors (expected when running standalone)
+        if (lowerError.includes('localhost:3000') || lowerError.includes('/api/')) {
+          return false;
+        }
+        // Ignore favicon errors
+        if (lowerError.includes('favicon')) {
+          return false;
+        }
+        // Ignore network/fetch errors (expected without backend)
+        if (lowerError.includes('failed to fetch') || lowerError.includes('network error')) {
+          return false;
+        }
+        // Ignore ERR_CONNECTION_REFUSED (backend not running)
+        if (lowerError.includes('err_connection_refused') || lowerError.includes('net::err')) {
+          return false;
+        }
+        // Ignore HttpErrorResponse from Angular HTTP client (backend not running)
+        if (lowerError.includes('httperrorresponse') || lowerError.includes('http error')) {
+          return false;
+        }
+        // Ignore SSE connection errors (expected without backend)
+        if (lowerError.includes('sse') || lowerError.includes('eventsource')) {
+          return false;
+        }
+        // Ignore "backend returned code 0" errors (connection refused)
+        if (lowerError.includes('backend returned code 0') || lowerError.includes('code 0')) {
+          return false;
+        }
+        // Ignore conversation loading errors (expected without backend)
+        if (lowerError.includes('getconversations') || lowerError.includes('conversation')) {
+          return false;
+        }
+        // Ignore isTrusted errors (network related)
+        if (lowerError.includes('istrusted')) {
+          return false;
+        }
+        return true;
+      });
+
+      // Log any critical errors found for debugging
+      if (criticalErrors.length > 0) {
+        console.log('Critical console errors found:', criticalErrors);
+      }
+
+      expect(criticalErrors).toHaveLength(0);
+    });
+
+    test('should have no "Cannot read property of undefined" errors', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      const undefinedErrors = consoleErrors.filter(
+        (error) =>
+          error.includes('Cannot read property') ||
+          error.includes('Cannot read properties') ||
+          error.includes('of undefined') ||
+          error.includes('of null'),
+      );
+
+      expect(undefinedErrors).toHaveLength(0);
+    });
+
+    test('should have no Angular errors', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      const angularErrors = consoleErrors.filter(
+        (error) =>
+          error.includes('NG') ||
+          error.includes('Angular') ||
+          error.includes('ExpressionChangedAfterItHasBeenCheckedError'),
+      );
+
+      expect(angularErrors).toHaveLength(0);
+    });
+
+    test('should have no 404 errors for assets', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Filter to only asset-related 404s (exclude API calls)
+      const asset404s = networkErrors.filter(
+        (error) =>
+          error.status === 404 &&
+          !error.url.includes('/api/') &&
+          !error.url.includes('localhost:3000'),
+      );
+
+      if (asset404s.length > 0) {
+        console.log('Asset 404 errors:', asset404s);
+      }
+
+      expect(asset404s).toHaveLength(0);
+    });
+  });
+
+  // ============================================================
+  // 3.5 Network Tab Check
+  // ============================================================
+  test.describe('3.5 Network Tab Check', () => {
+    test('should load main.js successfully', async ({ page }) => {
+      const jsRequests: string[] = [];
+
+      page.on('response', (response) => {
+        if (response.url().includes('main') && response.url().endsWith('.js')) {
+          jsRequests.push(response.url());
+          expect(response.status()).toBe(200);
+        }
+      });
+
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Verify main.js was loaded
+      expect(jsRequests.length).toBeGreaterThan(0);
+    });
+
+    test('should load styles successfully', async ({ page }) => {
+      const styleLoaded = { found: false };
+
+      page.on('response', (response) => {
+        if (response.url().includes('styles') && response.url().endsWith('.css')) {
+          expect(response.status()).toBe(200);
+          styleLoaded.found = true;
+        }
+      });
+
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Styles might be inlined in production builds
+      if (!styleLoaded.found) {
+        // Check for inline styles
+        const hasInlineStyles = await page.locator('style').count();
+        expect(hasInlineStyles).toBeGreaterThan(0);
+      }
+    });
+
+    test('should load all critical assets (no 404s)', async ({ page }) => {
+      const failed404s: string[] = [];
+
+      page.on('response', (response) => {
+        // Only check for static assets, not API calls
+        const url = response.url();
+        if (
+          response.status() === 404 &&
+          !url.includes('/api/') &&
+          !url.includes('localhost:3000') &&
+          (url.endsWith('.js') ||
+            url.endsWith('.css') ||
+            url.endsWith('.woff') ||
+            url.endsWith('.woff2') ||
+            url.endsWith('.ttf') ||
+            url.endsWith('.png') ||
+            url.endsWith('.svg') ||
+            url.endsWith('.ico'))
+        ) {
+          failed404s.push(url);
+        }
+      });
+
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      expect(failed404s).toHaveLength(0);
+    });
+  });
+
+  // ============================================================
+  // 3.6 Chat Page Visual Inspection
+  // ============================================================
+  test.describe('3.6 Chat Page Visual Inspection', () => {
+    test('should show welcome screen or chat interface', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Either welcome screen or messages area should be visible
+      const welcomeScreen = page.locator('.welcome-screen');
+      const messagesArea = page.locator('.messages-area, .chat-container');
+
+      const hasWelcome = await welcomeScreen.isVisible().catch(() => false);
+      const hasMessages = await messagesArea.isVisible().catch(() => false);
+
+      expect(hasWelcome || hasMessages).toBe(true);
+    });
+
+    test('should show message input field', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      const messageInput = page.locator(
+        '.message-input, textarea[placeholder], input[type="text"]',
+      );
+      await expect(messageInput.first()).toBeVisible();
+    });
+
+    test('should show send button and be styled', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      const sendButton = page.locator('.send-button, button[type="submit"], button:has(mat-icon)');
+      await expect(sendButton.first()).toBeVisible();
+
+      // Check it has some styling (background color, not default)
+      const hasStyle = await sendButton.first().evaluate((el) => {
+        const styles = getComputedStyle(el);
+        return styles.backgroundColor !== 'rgba(0, 0, 0, 0)' || styles.color !== 'rgb(0, 0, 0)';
+      });
+
+      expect(hasStyle).toBe(true);
+    });
+
+    test('should show sidebar toggle button', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      const hamburgerButton = page.locator('.hamburger-button, [aria-label*="menu"], mat-icon:has-text("menu")');
+      await expect(hamburgerButton.first()).toBeVisible();
+    });
+
+    test('should have no broken/overlapping layout elements', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Check that main container has reasonable dimensions
+      const mainContent = page.locator('.main-content, .chat-container, main');
+      const box = await mainContent.first().boundingBox();
+
+      expect(box).not.toBeNull();
+      expect(box!.width).toBeGreaterThan(200);
+      expect(box!.height).toBeGreaterThan(200);
+
+      // Check that input area is visible at bottom
+      const inputArea = page.locator('.input-container, .message-input').first();
+      const inputBox = await inputArea.boundingBox();
+
+      expect(inputBox).not.toBeNull();
+      expect(inputBox!.y).toBeGreaterThan(100); // Should be below header
+    });
+  });
+
+  // ============================================================
+  // 3.7 Navigation Test
+  // ============================================================
+  test.describe('3.7 Navigation Test', () => {
+    test('should toggle sidebar with button click', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Find and click hamburger button
+      const hamburgerButton = page.locator('.hamburger-button, [aria-label*="menu"]').first();
+      await hamburgerButton.click();
+
+      // Wait for sidebar animation
+      await page.waitForTimeout(500);
+
+      // Sidebar should be visible
+      const sidebar = page.locator('.conversation-sidebar, .sidebar, aside');
+      await expect(sidebar.first()).toBeVisible();
+
+      // Click close button or overlay to close
+      const closeButton = page.locator('.close-button, .sidebar-close, .overlay').first();
+      if (await closeButton.isVisible()) {
+        await closeButton.click();
+        await page.waitForTimeout(500);
+      }
+    });
+
+    test('should navigate to /explore', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Dismiss network error dialog before navigation
+      await dismissNetworkErrorDialog(page);
+
+      // Navigate to explore
+      await topNavPage.navigateToExplore();
+      await page.waitForURL(/\/explore/);
+
+      expect(page.url()).toContain('/explore');
+
+      // Page should have content
+      const heading = page.locator('h1, h2, .page-title');
+      await expect(heading.first()).toBeVisible();
+    });
+
+    test('should navigate to /account', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Dismiss network error dialog before navigation
+      await dismissNetworkErrorDialog(page);
+
+      // Navigate to account
+      await topNavPage.navigateToAccount();
+      await page.waitForURL(/\/account/);
+
+      expect(page.url()).toContain('/account');
+
+      // Page should have content
+      const heading = page.locator('h1, h2, .page-title');
+      await expect(heading.first()).toBeVisible();
+    });
+
+    test('should navigate back to /chat', async ({ page }) => {
+      await page.goto('/explore');
+      await page.waitForLoadState('networkidle');
+
+      // Navigate to chat
+      await chatPage.navigate();
+      await page.waitForURL(/\/chat/);
+
+      expect(page.url()).toContain('/chat');
+    });
+
+    test('should support browser back/forward buttons', async ({ page }) => {
+      // Start at chat
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Dismiss network error dialog before navigation
+      await dismissNetworkErrorDialog(page);
+
+      // Go to explore
+      await topNavPage.navigateToExplore();
+      await page.waitForURL(/\/explore/);
+
+      // Go back
+      await page.goBack();
+      await page.waitForURL(/\/chat/);
+      expect(page.url()).toContain('/chat');
+
+      // Dismiss any error dialog that appears after going back
+      await dismissNetworkErrorDialog(page);
+
+      // Go forward
+      await page.goForward();
+      await page.waitForURL(/\/explore/);
+      expect(page.url()).toContain('/explore');
+    });
+  });
+
+  // ============================================================
+  // 3.8 Responsive Check
+  // ============================================================
+  test.describe('3.8 Responsive Check', () => {
+    test('should render correctly at desktop width', async ({ page }) => {
+      await page.setViewportSize({ width: 1920, height: 1080 });
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Main content should be visible
+      const mainContent = page.locator('.main-content, .chat-container, main');
+      await expect(mainContent.first()).toBeVisible();
+
+      // No horizontal scrollbar
+      const hasHorizontalScroll = await page.evaluate(() => {
+        return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+      });
+      expect(hasHorizontalScroll).toBe(false);
+    });
+
+    test('should be functional at mobile width (~375px)', async ({ page }) => {
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Main content should be visible
+      const mainContent = page.locator('.main-content, .chat-container, main');
+      await expect(mainContent.first()).toBeVisible();
+
+      // Message input should still be visible
+      const messageInput = page.locator('.message-input, textarea');
+      await expect(messageInput.first()).toBeVisible();
+
+      // Hamburger button should be visible
+      const hamburgerButton = page.locator('.hamburger-button, [aria-label*="menu"]');
+      await expect(hamburgerButton.first()).toBeVisible();
+    });
+
+    test('should be functional at tablet width (~768px)', async ({ page }) => {
+      await page.setViewportSize({ width: 768, height: 1024 });
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Dismiss network error dialog before interaction
+      await dismissNetworkErrorDialog(page);
+
+      // Main content should be visible
+      const mainContent = page.locator('.main-content, .chat-container, main');
+      await expect(mainContent.first()).toBeVisible();
+
+      // Navigation should work
+      await topNavPage.navigateToExplore();
+      await page.waitForURL(/\/explore/);
+      expect(page.url()).toContain('/explore');
+    });
+  });
+
+  // ============================================================
+  // 3.9 Theme/Styling
+  // ============================================================
+  test.describe('3.9 Theme/Styling', () => {
+    test('should render theme correctly', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Check that body has background color (not default white/transparent)
+      const bodyBg = await page.evaluate(() => {
+        const styles = getComputedStyle(document.body);
+        return styles.backgroundColor;
+      });
+
+      // Should have some background styling
+      expect(bodyBg).toBeTruthy();
+    });
+
+    test('should load Material icons', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Find Material icons
+      const matIcons = page.locator('mat-icon');
+      const iconCount = await matIcons.count();
+
+      // Should have at least some icons (hamburger, send, etc.)
+      expect(iconCount).toBeGreaterThan(0);
+
+      // Check first icon has content (font loaded correctly)
+      if (iconCount > 0) {
+        const firstIcon = matIcons.first();
+        const iconText = await firstIcon.textContent();
+        expect(iconText?.length).toBeGreaterThan(0);
+
+        // Check icon has proper dimensions (font rendered)
+        const box = await firstIcon.boundingBox();
+        expect(box?.width).toBeGreaterThan(0);
+        expect(box?.height).toBeGreaterThan(0);
+      }
+    });
+
+    test('should render fonts correctly', async ({ page }) => {
+      await page.goto('/chat');
+      await page.waitForLoadState('networkidle');
+
+      // Check that text elements have proper font styling
+      const greeting = page.locator('.greeting, h1, h2, .page-title').first();
+
+      if (await greeting.isVisible()) {
+        const fontFamily = await greeting.evaluate((el) => {
+          return getComputedStyle(el).fontFamily;
+        });
+
+        // Should have a font family set (not just default serif)
+        expect(fontFamily).toBeTruthy();
+        expect(fontFamily).not.toBe('serif');
+      }
+
+      // Check text is readable (has proper font-size)
+      const textElement = page.locator('body').first();
+      const fontSize = await textElement.evaluate((el) => {
+        return parseFloat(getComputedStyle(el).fontSize);
+      });
+
+      expect(fontSize).toBeGreaterThanOrEqual(12); // Minimum readable size
+    });
+  });
+
+  // ============================================================
+  // Summary Screenshot
+  // ============================================================
+  test('should capture validation screenshot', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/chat');
+    await page.waitForLoadState('networkidle');
+
+    // Wait a moment for any animations
+    await page.waitForTimeout(1000);
+
+    // Take screenshot for validation evidence
+    await page.screenshot({
+      path: 'e2e/screenshots/standalone-validation.png',
+      fullPage: false,
+    });
+  });
+});

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -28,7 +28,10 @@
     "e2e:full:report": "playwright show-report e2e/playwright-report-e2e",
     "e2e:preflight": "playwright test --config=playwright.e2e.config.ts tests/e2e/preflight.e2e.spec.ts",
     "serve:dev": "ng serve --configuration development --host 0.0.0.0 --port 4200",
-    "analyze": "npx webpack-bundle-analyzer dist/main.js"
+    "analyze": "npx webpack-bundle-analyzer dist/main.js",
+    "validate": "./scripts/frontend-validate.sh",
+    "validate:standalone": "playwright test standalone-validation.spec.ts",
+    "validate:standalone:headed": "playwright test standalone-validation.spec.ts --headed"
   },
   "dependencies": {
     "@angular/animations": "^20.3.1",

--- a/packages/frontend/scripts/frontend-validate.sh
+++ b/packages/frontend/scripts/frontend-validate.sh
@@ -1,0 +1,378 @@
+#!/bin/bash
+#
+# Frontend Standalone Validation Script for MCP Everything
+# Validates the Angular frontend builds, serves, and renders correctly
+# Per Issue #89 (Layer 3: Frontend Standalone Validation)
+#
+# Usage: ./scripts/frontend-validate.sh [--markdown] [--skip-browser]
+#
+# Options:
+#   --markdown      Output results in markdown format (for GitHub issue)
+#   --skip-browser  Skip Playwright browser tests (build validation only)
+#
+
+set -e
+
+# Colors for terminal output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+FRONTEND_PORT=4200
+BUILD_TIMEOUT=180
+DEV_SERVER_TIMEOUT=60
+
+# Counters
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+
+# Options
+MARKDOWN_OUTPUT=false
+SKIP_BROWSER=false
+
+# Parse arguments
+for arg in "$@"; do
+  case $arg in
+    --markdown)
+      MARKDOWN_OUTPUT=true
+      shift
+      ;;
+    --skip-browser)
+      SKIP_BROWSER=true
+      shift
+      ;;
+  esac
+done
+
+# Get script directory and project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Output functions
+print_header() {
+  if [ "$MARKDOWN_OUTPUT" = true ]; then
+    echo ""
+    echo "### $1"
+  else
+    echo -e "\n${BLUE}=== $1 ===${NC}"
+  fi
+}
+
+print_pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  if [ "$MARKDOWN_OUTPUT" = true ]; then
+    echo "- [x] $1"
+  else
+    echo -e "${GREEN}[PASS]${NC} $1"
+  fi
+}
+
+print_fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  if [ "$MARKDOWN_OUTPUT" = true ]; then
+    echo "- [ ] $1"
+    if [ -n "$2" ]; then
+      echo "  > Fix: $2"
+    fi
+  else
+    echo -e "${RED}[FAIL]${NC} $1"
+    if [ -n "$2" ]; then
+      echo -e "       ${YELLOW}Fix: $2${NC}"
+    fi
+  fi
+}
+
+print_warn() {
+  WARN_COUNT=$((WARN_COUNT + 1))
+  if [ "$MARKDOWN_OUTPUT" = true ]; then
+    echo "- [x] $1 (warning)"
+  else
+    echo -e "${YELLOW}[WARN]${NC} $1"
+  fi
+}
+
+print_info() {
+  if [ "$MARKDOWN_OUTPUT" = true ]; then
+    echo "  > $1"
+  else
+    echo -e "       $1"
+  fi
+}
+
+# Cleanup function
+cleanup() {
+  if [ -n "$DEV_SERVER_PID" ] && kill -0 "$DEV_SERVER_PID" 2>/dev/null; then
+    print_info "Stopping dev server (PID: $DEV_SERVER_PID)..."
+    kill "$DEV_SERVER_PID" 2>/dev/null || true
+    wait "$DEV_SERVER_PID" 2>/dev/null || true
+  fi
+
+  # Also cleanup any orphaned ng serve processes
+  pkill -f "ng serve" 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+# ============================================================
+# 3.1 Build Frontend
+# ============================================================
+check_build() {
+  print_header "3.1 Build Frontend"
+
+  cd "$FRONTEND_ROOT"
+
+  # Clean previous build
+  rm -rf dist/
+
+  # Run build and capture output
+  print_info "Running npm run build..."
+  BUILD_START=$(date +%s)
+
+  if BUILD_OUTPUT=$(npm run build 2>&1); then
+    BUILD_END=$(date +%s)
+    BUILD_TIME=$((BUILD_END - BUILD_START))
+
+    print_pass "Angular compilation succeeds"
+
+    # Check for template errors (Angular emits these as errors)
+    if echo "$BUILD_OUTPUT" | grep -qi "template.*error\|NG[0-9]\+:"; then
+      print_fail "Template errors found in build output"
+    else
+      print_pass "No template errors"
+    fi
+
+    # Check for TypeScript errors
+    if echo "$BUILD_OUTPUT" | grep -qi "TS[0-9]\+:.*error"; then
+      print_fail "TypeScript errors found in build output"
+    else
+      print_pass "No TypeScript errors"
+    fi
+
+    # Check dist folder
+    if [ -d "dist/" ]; then
+      DIST_SIZE=$(du -sh dist/ | cut -f1)
+      print_pass "dist/ folder created ($DIST_SIZE)"
+    else
+      print_fail "dist/ folder not created" "Check build output for errors"
+    fi
+
+    # Check build time
+    if [ "$BUILD_TIME" -lt 120 ]; then
+      print_pass "Build completes in reasonable time (${BUILD_TIME}s)"
+    else
+      print_warn "Build took ${BUILD_TIME}s (> 2 minutes)"
+    fi
+  else
+    print_fail "Angular compilation failed" "Check npm run build output for errors"
+    print_info "Build output (last 20 lines):"
+    echo "$BUILD_OUTPUT" | tail -20
+    return 1
+  fi
+}
+
+# ============================================================
+# 3.2 Start Dev Server
+# ============================================================
+check_dev_server() {
+  print_header "3.2 Start Dev Server"
+
+  cd "$FRONTEND_ROOT"
+
+  # Kill any existing dev server
+  pkill -f "ng serve" 2>/dev/null || true
+  sleep 1
+
+  # Start dev server in background
+  print_info "Starting dev server..."
+  npm run start > /tmp/ng-serve.log 2>&1 &
+  DEV_SERVER_PID=$!
+
+  # Wait for server to be ready
+  SERVER_READY=false
+  for i in $(seq 1 $DEV_SERVER_TIMEOUT); do
+    if curl -s http://localhost:$FRONTEND_PORT > /dev/null 2>&1; then
+      SERVER_READY=true
+      break
+    fi
+    sleep 1
+  done
+
+  if [ "$SERVER_READY" = true ]; then
+    print_pass "Dev server starts"
+    print_pass "Listening on port $FRONTEND_PORT"
+
+    # Check for build errors in log
+    if grep -qi "error\|ERROR" /tmp/ng-serve.log 2>/dev/null; then
+      if grep -qi "warning" /tmp/ng-serve.log 2>/dev/null; then
+        print_warn "Some warnings in dev server console"
+      fi
+      # Only fail if there are actual errors (not just the word in a path)
+      if grep -E "^\s*ERROR|error TS|error NG" /tmp/ng-serve.log 2>/dev/null; then
+        print_fail "Build errors in console" "Check ng serve output"
+      else
+        print_pass "No build errors in console"
+      fi
+    else
+      print_pass "No build errors in console"
+    fi
+  else
+    print_fail "Dev server did not start within ${DEV_SERVER_TIMEOUT}s"
+    print_info "Log output:"
+    cat /tmp/ng-serve.log | tail -20
+    return 1
+  fi
+}
+
+# ============================================================
+# 3.3 Access in Browser (Basic HTTP check)
+# ============================================================
+check_browser_access() {
+  print_header "3.3 Access in Browser"
+
+  # Check if page loads
+  HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$FRONTEND_PORT)
+
+  if [ "$HTTP_STATUS" = "200" ]; then
+    print_pass "Page loads (HTTP 200)"
+  else
+    print_fail "Page did not load (HTTP $HTTP_STATUS)"
+    return 1
+  fi
+
+  # Check if content is not blank
+  PAGE_SIZE=$(curl -s http://localhost:$FRONTEND_PORT | wc -c)
+  if [ "$PAGE_SIZE" -gt 1000 ]; then
+    print_pass "Page has content (${PAGE_SIZE} bytes)"
+  else
+    print_fail "Page appears blank or minimal (${PAGE_SIZE} bytes)"
+  fi
+
+  # Check for app-root in HTML
+  if curl -s http://localhost:$FRONTEND_PORT | grep -q "<app-root"; then
+    print_pass "Angular app-root element present"
+  else
+    print_fail "Angular app-root element missing" "Check index.html has <app-root></app-root>"
+  fi
+}
+
+# ============================================================
+# 3.5 Network/Asset Check (main.js, styles)
+# ============================================================
+check_assets() {
+  print_header "3.5 Network/Asset Check"
+
+  # Get the main page to find asset URLs
+  MAIN_HTML=$(curl -s http://localhost:$FRONTEND_PORT)
+
+  # Check main.js (could be main.js or main.*.js)
+  MAIN_JS_URL=$(echo "$MAIN_HTML" | grep -oP 'src="[^"]*main[^"]*\.js"' | head -1 | cut -d'"' -f2)
+  if [ -n "$MAIN_JS_URL" ]; then
+    if curl -s -o /dev/null -w "%{http_code}" "http://localhost:$FRONTEND_PORT$MAIN_JS_URL" | grep -q "200"; then
+      print_pass "main.js loads successfully"
+    else
+      print_fail "main.js failed to load (404)"
+    fi
+  else
+    # Try default path
+    if curl -s -o /dev/null -w "%{http_code}" "http://localhost:$FRONTEND_PORT/main.js" | grep -q "200"; then
+      print_pass "main.js loads successfully"
+    else
+      print_warn "Could not locate main.js in page source"
+    fi
+  fi
+
+  # Check styles (styles.css or styles.*.css)
+  STYLES_URL=$(echo "$MAIN_HTML" | grep -oP 'href="[^"]*styles[^"]*\.css"' | head -1 | cut -d'"' -f2)
+  if [ -n "$STYLES_URL" ]; then
+    if curl -s -o /dev/null -w "%{http_code}" "http://localhost:$FRONTEND_PORT$STYLES_URL" | grep -q "200"; then
+      print_pass "styles.css loads successfully"
+    else
+      print_fail "styles.css failed to load (404)"
+    fi
+  else
+    # Check if inline styles exist (Angular sometimes inlines styles)
+    if echo "$MAIN_HTML" | grep -q "<style"; then
+      print_pass "Styles are inlined in HTML"
+    else
+      print_warn "Could not locate styles.css in page source"
+    fi
+  fi
+
+  # Check for Material Icons font (either via CDN or bundled)
+  if echo "$MAIN_HTML" | grep -qi "material.*icons\|fonts.googleapis"; then
+    print_pass "Material Icons font reference found"
+  else
+    print_warn "Material Icons font link not found in HTML (may be loaded dynamically)"
+  fi
+}
+
+# ============================================================
+# Summary
+# ============================================================
+print_summary() {
+  if [ "$MARKDOWN_OUTPUT" = true ]; then
+    echo ""
+    echo "## Summary"
+    echo "- **Passed**: $PASS_COUNT"
+    echo "- **Failed**: $FAIL_COUNT"
+    echo "- **Warnings**: $WARN_COUNT"
+    echo ""
+    if [ "$FAIL_COUNT" -eq 0 ]; then
+      echo "> All build checks passed! Run Playwright tests for full browser validation."
+    else
+      echo "> Some checks failed. Please fix the issues above before proceeding."
+    fi
+  else
+    echo -e "\n${BLUE}=== Summary ===${NC}"
+    echo -e "${GREEN}Passed:${NC}   $PASS_COUNT"
+    echo -e "${RED}Failed:${NC}   $FAIL_COUNT"
+    echo -e "${YELLOW}Warnings:${NC} $WARN_COUNT"
+    echo ""
+    if [ "$FAIL_COUNT" -eq 0 ]; then
+      echo -e "${GREEN}All build checks passed! Run Playwright tests for full browser validation.${NC}"
+      echo -e "  npm run e2e -- standalone-validation.spec.ts"
+    else
+      echo -e "${RED}Some checks failed. Please fix the issues above before proceeding.${NC}"
+    fi
+  fi
+}
+
+# ============================================================
+# Main
+# ============================================================
+main() {
+  if [ "$MARKDOWN_OUTPUT" = true ]; then
+    echo "## Frontend Standalone Validation Results"
+    echo ""
+    echo "Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+  else
+    echo -e "${BLUE}MCP Everything - Frontend Standalone Validation${NC}"
+    echo "Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
+  fi
+
+  # Run build check first
+  check_build || true
+
+  if [ "$SKIP_BROWSER" = false ]; then
+    # Start dev server and run checks
+    check_dev_server || true
+    check_browser_access || true
+    check_assets || true
+  else
+    print_info "Skipping browser checks (--skip-browser flag)"
+  fi
+
+  print_summary
+
+  # Exit with appropriate code
+  if [ "$FAIL_COUNT" -gt 0 ]; then
+    exit 1
+  fi
+  exit 0
+}
+
+main


### PR DESCRIPTION
## Summary
- Add Layer 3 frontend standalone validation per issue #89
- Create shell script for build validation (`frontend-validate.sh`)
- Create 27 Playwright tests for browser-based validation
- Fix TopNavPage selectors to match actual HTML structure

## Changes
| File | Description |
|------|-------------|
| `packages/frontend/scripts/frontend-validate.sh` | Build validation script |
| `packages/frontend/e2e/tests/standalone-validation.spec.ts` | 27 Playwright tests |
| `packages/frontend/package.json` | Add validation scripts |
| `packages/frontend/e2e/page-objects/top-nav.page.ts` | Fix selectors |

## Test Coverage
All checklist items from issue #89 are covered:
- [x] 3.1 Build Frontend (via shell script)
- [x] 3.2 Start Dev Server (Playwright auto-starts)
- [x] 3.3 Access in Browser (3 tests)
- [x] 3.4 Browser Console Check (4 tests)
- [x] 3.5 Network Tab Check (3 tests)
- [x] 3.6 Chat Page Visual Inspection (5 tests)
- [x] 3.7 Navigation Test (5 tests)
- [x] 3.8 Responsive Check (3 tests)
- [x] 3.9 Theme/Styling (3 tests)
- [x] Screenshot capture (1 test)

## Test plan
- [x] Run `npm run validate --skip-browser` - Build validation passes
- [x] Run `npm run validate:standalone` - All 27 Playwright tests pass
- [x] Tests correctly filter out expected backend connection errors
- [x] Tests handle Material snackbar dialogs when backend is unavailable

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)