### PR TITLE
fix(frontend): Replace hardcoded API URL with environment config

### DIFF
--- a/packages/frontend/src/app/core/services/chat.service.ts
+++ b/packages/frontend/src/app/core/services/chat.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, BehaviorSubject, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 import { ConversationService, ConversationMessage } from './conversation.service';
+import { environment } from '../../../environments/environment';
 
 export interface ChatMessage {
   content: string;
@@ -27,7 +28,7 @@ export interface ChatResponse {
   providedIn: 'root'
 })
 export class ChatService {
-  private readonly baseUrl = 'http://localhost:3000/api';
+  private readonly baseUrl = `${environment.apiUrl}/api`;
   private messagesSubject = new BehaviorSubject<ChatMessage[]>([]);
   public messages$ = this.messagesSubject.asObservable();
 

--- a/packages/frontend/src/app/core/services/conversation.service.ts
+++ b/packages/frontend/src/app/core/services/conversation.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable, throwError, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
 
 export interface Conversation {
   id: string;
@@ -67,7 +68,7 @@ export interface Deployment {
   providedIn: 'root'
 })
 export class ConversationService {
-  private readonly baseUrl = 'http://localhost:3000/api';
+  private readonly baseUrl = `${environment.apiUrl}/api`;
 
   constructor(private http: HttpClient) {}
 


### PR DESCRIPTION
## Summary
- Replaced hardcoded `http://localhost:3000/api` with `${environment.apiUrl}/api` in `chat.service.ts` and `conversation.service.ts`
- Enables proper production deployment by using environment-specific API URLs

## Files Changed
- `packages/frontend/src/app/core/services/chat.service.ts:30` - Now uses `environment.apiUrl`
- `packages/frontend/src/app/core/services/conversation.service.ts:70` - Now uses `environment.apiUrl`

## Test Plan
- [x] Frontend build passes
- [ ] Verify dev environment still works (uses `http://localhost:3000`)
- [ ] Verify production build uses configured API URL

## Related
- Fixes code quality issue noted in #86 (Layer 4 Update comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)