### PR TITLE
feat(e2e): Add Layer 5 core features tests (#91)

### DIFF
--- a/packages/frontend/e2e/README.md
+++ b/packages/frontend/e2e/README.md
@@ -482,9 +482,75 @@ Current coverage:
 - ✅ Security (XSS prevention, input validation)
 - ✅ Keyboard navigation
 - ✅ Mobile responsive design
+- ✅ Core Features - Chat, AI, Generation (Layer 5)
 - ⏳ Download functionality (mocked)
 - ⏳ Account settings
 - ⏳ Explore page
+
+## Layer 5: Core Features Tests
+
+The core features tests validate the complete AI pipeline:
+
+### Prerequisites
+
+1. **Backend running**: `cd packages/backend && npm run start:dev`
+2. **ANTHROPIC_API_KEY**: Must be configured in backend `.env`
+3. **Frontend running**: `npm run start` (auto-started by Playwright)
+
+### Running Core Features Tests
+
+```bash
+# Run all core features tests (mocked + real API)
+npm run e2e:core-features
+
+# Run with visible browser
+npm run e2e:core-features:headed
+
+# Run only mocked tests (fast, free)
+npm run e2e:core-features:mocked
+
+# Run only real API tests (slow, costs money)
+npm run e2e:core-features:real
+
+# Debug mode
+npm run e2e:core-features:debug
+```
+
+### Test Structure
+
+| Test | Mode | Description | Time |
+|------|------|-------------|------|
+| 5.1 Send Message | Mocked | User message appears in chat | < 2s |
+| 5.2 AI Response | Mocked | Streaming response via SSE | < 2s |
+| 5.3 Help Intent | Mocked | Quick help response | < 2s |
+| 5.4 GitHub Generation | Real API | Generate MCP server from URL | 2-5 min |
+| 5.5 Download | Real API | Download generated ZIP | 5s |
+| 5.6 Service Name | Real API | Handle "Stripe API" input | 30-60s |
+| 5.7 Natural Language | Real API | Handle description input | 30-60s |
+| 5.8 Clarification | Real API | Vague input triggers questions | 1-2 min |
+| 5.9 Context | Real API | Conversation memory | 10-30s |
+
+### Cost Considerations
+
+- **Mocked tests** (5.1-5.3): Free, fast, reliable
+- **Real API tests** (5.4-5.9): ~$0.001-0.01 per test
+- **Full suite**: ~$0.05-0.10 total
+- **Run time**: ~10-15 minutes total
+
+### Troubleshooting
+
+**No response after sending message:**
+- Check backend logs for errors
+- Verify ANTHROPIC_API_KEY is valid
+- Check SSE connection in Network tab
+
+**Progress stuck on one phase:**
+- Check backend logs for stuck node
+- May be rate limited by Claude API
+
+**Generation fails:**
+- Check refinement loop iteration count
+- Look for compilation errors in logs
 
 ## Known Issues
 
@@ -524,4 +590,4 @@ For issues or questions:
 
 ---
 
-**Last Updated**: October 2025
+**Last Updated**: December 2025

--- a/packages/frontend/e2e/tests/core-features.spec.ts
+++ b/packages/frontend/e2e/tests/core-features.spec.ts
@@ -1,0 +1,434 @@
+/**
+ * Layer 5: Core Features - Chat, AI, Generation Tests
+ *
+ * This test suite validates the core functionality per Issue #91:
+ * - Sending messages
+ * - Receiving AI responses
+ * - Generating MCP servers
+ *
+ * HYBRID APPROACH:
+ * - Tests 5.1-5.3: Use MOCKED backend (fast, free, reliable)
+ * - Tests 5.4-5.9: Use REAL Claude API (validates actual AI behavior)
+ *
+ * Run with: npm run e2e:core-features
+ */
+
+import { test, expect } from '@playwright/test';
+import { ChatPage } from '../page-objects/chat.page';
+import { MockBackend } from '../fixtures/mock-backend';
+import {
+  CoreFeaturesBackend,
+  generateTestSessionId,
+} from '../fixtures/integration-backend';
+import {
+  MOCK_SSE_EVENTS,
+  MOCK_GENERATED_CODE,
+  API_ENDPOINTS,
+} from '../fixtures/test-data';
+
+// Backend configuration
+const BACKEND_URL = 'http://localhost:3000';
+const FRONTEND_URL = 'http://localhost:4200';
+
+// ============================================================================
+// PART A: Mocked Tests (5.1-5.3) - Fast, no API costs
+// ============================================================================
+
+test.describe('Layer 5: Core Features - Chat, AI, Generation', () => {
+  test.describe('5.1-5.3 Basic Chat (Mocked)', () => {
+    let chatPage: ChatPage;
+    let mockBackend: MockBackend;
+
+    test.beforeEach(async ({ page }) => {
+      chatPage = new ChatPage(page);
+      mockBackend = new MockBackend(page);
+    });
+
+    test('5.1 sends message and shows in chat', async ({ page }) => {
+      // Setup mocks
+      await mockBackend.mockChatMessage({ success: true, conversationId: 'test-conv-1' });
+      await mockBackend.mockSSEStream([
+        { type: 'progress', message: 'Processing...', timestamp: new Date().toISOString() },
+      ]);
+      await mockBackend.mockHealthCheck();
+
+      // Navigate to chat
+      await chatPage.navigate();
+      await chatPage.wait(1000);
+
+      // Verify welcome screen is visible
+      expect(await chatPage.isWelcomeScreenVisible()).toBe(true);
+
+      // Type "Hello" in chat input
+      await chatPage.typeMessage('Hello');
+      expect(await chatPage.getMessageInputValue()).toBe('Hello');
+
+      // Click Send button
+      await chatPage.clickSend();
+
+      // Verify user message appears in chat
+      await chatPage.waitForUserMessage(5000);
+      const lastUserMessage = await chatPage.getLastUserMessage();
+      expect(lastUserMessage).toContain('Hello');
+
+      // Verify loading state shows (hourglass icon on send button)
+      // Note: This may be fast, so we check if either loading or complete
+      const isLoading = await chatPage.isLoading();
+      // Loading state is transient, so we just verify no errors occurred
+      expect(await chatPage.isErrorMessageVisible()).toBe(false);
+    });
+
+    test('5.2 receives streaming AI response', async ({ page }) => {
+      // Setup mocks with progress -> result -> complete flow
+      await mockBackend.mockChatMessage({ success: true, conversationId: 'test-conv-2' });
+      await mockBackend.mockSSEStream([
+        {
+          type: 'progress',
+          message: 'Analyzing your request...',
+          timestamp: new Date().toISOString(),
+        },
+        {
+          type: 'result',
+          message: 'I can help you with many things! I can generate MCP servers from GitHub repositories, API specifications, or natural language descriptions.',
+          timestamp: new Date().toISOString(),
+        },
+        {
+          type: 'complete',
+          message: 'Response complete',
+          timestamp: new Date().toISOString(),
+        },
+      ]);
+      await mockBackend.mockHealthCheck();
+
+      // Navigate to chat
+      await chatPage.navigate();
+      await chatPage.wait(1000);
+
+      // Send message
+      await chatPage.sendMessage('What can you help me with?');
+
+      // Verify user message appears
+      await chatPage.waitForUserMessage(5000);
+
+      // Wait for assistant response
+      await chatPage.waitForAssistantResponse(10000);
+
+      // Verify assistant response appears and is relevant
+      const assistantMessage = await chatPage.getLastAssistantMessage();
+      expect(assistantMessage.length).toBeGreaterThan(0);
+      expect(assistantMessage.toLowerCase()).toContain('help');
+
+      // Verify loading state clears
+      await chatPage.waitForLoadingComplete(5000);
+    });
+
+    test('5.3 responds to help request quickly', async ({ page }) => {
+      // Setup mocks for help response
+      await mockBackend.mockChatMessage({ success: true, conversationId: 'test-conv-3' });
+      await mockBackend.mockSSEStream([
+        {
+          type: 'progress',
+          message: 'Processing help request...',
+          timestamp: new Date().toISOString(),
+        },
+        {
+          type: 'result',
+          message: `I'm MCP Everything, an AI-powered platform that helps you generate Model Context Protocol (MCP) servers. Here's what I can do:
+
+1. **Generate MCP servers from GitHub repositories** - Just paste a URL
+2. **Create servers from API specifications** - Describe your API
+3. **Build servers from natural language** - Tell me what tools you need
+
+Try saying: "Create an MCP server for https://github.com/sindresorhus/is"`,
+          timestamp: new Date().toISOString(),
+        },
+        {
+          type: 'complete',
+          message: 'Help response complete',
+          timestamp: new Date().toISOString(),
+        },
+      ]);
+      await mockBackend.mockHealthCheck();
+
+      // Navigate to chat
+      await chatPage.navigate();
+      await chatPage.wait(1000);
+
+      // Record start time
+      const startTime = Date.now();
+
+      // Send "help"
+      await chatPage.sendMessage('help');
+
+      // Wait for assistant response
+      await chatPage.waitForAssistantResponse(10000);
+
+      // Verify response time < 10s
+      const responseTime = Date.now() - startTime;
+      expect(responseTime).toBeLessThan(10000);
+
+      // Verify response explains capabilities
+      const assistantMessage = await chatPage.getLastAssistantMessage();
+      expect(assistantMessage.toLowerCase()).toContain('mcp');
+
+      // Verify no error messages
+      expect(await chatPage.isErrorMessageVisible()).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // PART B: Real API Tests (5.4-5.9) - Slow, costs money
+  // ============================================================================
+
+  test.describe('5.4-5.9 AI Generation (Real API)', () => {
+    // Extended timeout for AI operations
+    test.setTimeout(300000); // 5 minutes per test
+
+    // Run tests sequentially to control API costs
+    test.describe.configure({ mode: 'serial' });
+
+    let backend: CoreFeaturesBackend;
+    let chatPage: ChatPage;
+
+    // Store state between tests for context testing
+    let lastConversationId: string | null = null;
+    let generationSucceeded = false;
+
+    test.beforeAll(async () => {
+      // Verify backend is running and AI is ready
+      backend = new CoreFeaturesBackend({
+        backendUrl: BACKEND_URL,
+        frontendUrl: FRONTEND_URL,
+      });
+
+      const aiReady = await backend.isAIReady();
+      if (!aiReady.ready) {
+        throw new Error(
+          `AI services not ready: ${aiReady.error}. ` +
+          `Backend healthy: ${aiReady.backendHealthy}, ` +
+          `Chat service healthy: ${aiReady.chatServiceHealthy}. ` +
+          'Start backend with: cd packages/backend && npm run start:dev'
+        );
+      }
+    });
+
+    test.beforeEach(async ({ page }) => {
+      chatPage = new ChatPage(page);
+    });
+
+    test('5.4 generates MCP server from GitHub URL (CRITICAL)', async ({ page }) => {
+      // Navigate to chat
+      await chatPage.navigate();
+      await chatPage.wait(2000);
+
+      // Send generation request
+      const message = 'Create MCP server for https://github.com/sindresorhus/is';
+      await chatPage.sendMessage(message);
+
+      // Verify user message appears
+      await chatPage.waitForUserMessage(5000);
+
+      // Track phases - these should appear as progress messages
+      // Phase 1: Intent analysis
+      try {
+        await chatPage.waitForProgressMessage(30000);
+        const progressText = await chatPage.getProgressMessage();
+        expect(progressText.length).toBeGreaterThan(0);
+      } catch {
+        // Progress may be too fast to catch, continue
+      }
+
+      // Wait for generation to complete (download button appears)
+      // This is the critical success indicator
+      await chatPage.waitForGenerationComplete(300000); // 5 minutes
+
+      // Verify download button appeared
+      expect(await chatPage.hasDownloadZipButton()).toBe(true);
+
+      // Verify assistant message with summary appears
+      const assistantCount = await chatPage.getAssistantMessageCount();
+      expect(assistantCount).toBeGreaterThan(0);
+
+      // Verify no error messages
+      expect(await chatPage.isErrorMessageVisible()).toBe(false);
+
+      // Store state for subsequent tests
+      lastConversationId = chatPage.getConversationIdFromUrl();
+      generationSucceeded = true;
+    });
+
+    test('5.5 downloads generated code as ZIP', async ({ page }) => {
+      // This test depends on 5.4 succeeding
+      test.skip(!generationSucceeded, 'Skipping: Previous generation did not succeed');
+
+      // Navigate to chat (should have last conversation)
+      await chatPage.navigate();
+      await chatPage.wait(2000);
+
+      // If we have a conversation ID, navigate to it
+      if (lastConversationId) {
+        await chatPage.navigateToConversation(lastConversationId);
+        await chatPage.wait(2000);
+      }
+
+      // Verify download button is visible
+      const hasButton = await chatPage.hasDownloadZipButton();
+      if (!hasButton) {
+        // Re-generate if needed
+        await chatPage.sendMessage('Create MCP server for https://github.com/sindresorhus/is');
+        await chatPage.waitForGenerationComplete(300000);
+      }
+
+      // Click download and get file
+      const downloadPath = await chatPage.clickDownloadZip();
+
+      // Verify file was downloaded
+      expect(downloadPath).toBeTruthy();
+      expect(downloadPath.length).toBeGreaterThan(0);
+    });
+
+    test('5.6 handles service name input', async ({ page }) => {
+      // Navigate to chat
+      await chatPage.navigate();
+      await chatPage.wait(2000);
+
+      // Send service name request
+      await chatPage.sendMessage('Create MCP server for Stripe API');
+
+      // Verify user message appears
+      await chatPage.waitForUserMessage(5000);
+
+      // Wait for some response (either progress, clarification, or result)
+      await chatPage.waitForNewMessage(1, 60000);
+
+      // Verify intent was detected (should have progress or response)
+      const messageCount = await chatPage.getMessageCount();
+      expect(messageCount).toBeGreaterThan(1);
+
+      // Check if we got a response or clarification
+      const assistantCount = await chatPage.getAssistantMessageCount();
+      const progressCount = await chatPage.getProgressMessageCount();
+      expect(assistantCount + progressCount).toBeGreaterThan(0);
+    });
+
+    test('5.7 handles natural language description', async ({ page }) => {
+      // Navigate to chat
+      await chatPage.navigate();
+      await chatPage.wait(2000);
+
+      // Send natural language description
+      const description =
+        'I want an MCP server that converts temperatures between Celsius and Fahrenheit';
+      await chatPage.sendMessage(description);
+
+      // Verify user message appears
+      await chatPage.waitForUserMessage(5000);
+
+      // Wait for some response
+      await chatPage.waitForNewMessage(1, 60000);
+
+      // Verify AI understood and responded
+      const messageCount = await chatPage.getMessageCount();
+      expect(messageCount).toBeGreaterThan(1);
+
+      // Either generates or asks clarifying questions
+      const assistantCount = await chatPage.getAssistantMessageCount();
+      expect(assistantCount).toBeGreaterThan(0);
+    });
+
+    test('5.8 asks for clarification on vague input', async ({ page }) => {
+      // Navigate to chat
+      await chatPage.navigate();
+      await chatPage.wait(2000);
+
+      // Send vague message that should trigger clarification
+      await chatPage.sendMessage('Create an MCP server');
+
+      // Verify user message appears
+      await chatPage.waitForUserMessage(5000);
+
+      // Wait for AI response
+      await chatPage.waitForAssistantResponse(60000);
+
+      // Verify AI asks for clarification
+      const isClarifying = await chatPage.isClarificationBeingAsked();
+      const lastMessage = await chatPage.getLastAssistantMessage();
+
+      // Should either ask a question or provide guidance
+      expect(
+        isClarifying || lastMessage.includes('?') || lastMessage.toLowerCase().includes('what')
+      ).toBe(true);
+
+      // If clarification was requested, reply with details
+      if (isClarifying) {
+        const currentCount = await chatPage.getMessageCount();
+
+        // Send clarification
+        await chatPage.sendMessage(
+          'For managing a TODO list with add, complete, and delete tasks'
+        );
+
+        // Wait for response to clarification
+        await chatPage.waitForNewMessage(currentCount + 1, 120000);
+
+        // Verify generation proceeds or more specific questions asked
+        const newAssistantCount = await chatPage.getAssistantMessageCount();
+        expect(newAssistantCount).toBeGreaterThan(1);
+      }
+    });
+
+    test('5.9 maintains conversation context', async ({ page }) => {
+      // This test works best after a generation has completed
+      // Navigate to chat
+      await chatPage.navigate();
+      await chatPage.wait(2000);
+
+      // If we have a previous conversation, use it
+      if (lastConversationId) {
+        await chatPage.navigateToConversation(lastConversationId);
+        await chatPage.wait(2000);
+      } else {
+        // Generate something first
+        await chatPage.sendMessage('Create MCP server for a simple calculator with add and subtract');
+        await chatPage.waitForAssistantResponse(120000);
+      }
+
+      // Get current message count
+      const currentCount = await chatPage.getMessageCount();
+
+      // Ask about the context
+      await chatPage.sendMessage('What tools does this server have?');
+
+      // Wait for response
+      await chatPage.waitForNewMessage(currentCount + 1, 60000);
+
+      // Verify AI remembers previous context
+      const lastMessage = await chatPage.getLastAssistantMessage();
+
+      // Should relate to the generated server or ask for clarification about which server
+      expect(lastMessage.length).toBeGreaterThan(0);
+
+      // Should not be a "I don't know what you mean" type response
+      const confusionIndicators = [
+        "i don't understand",
+        'could you clarify',
+        "i'm not sure what you're referring to",
+        'what do you mean',
+      ];
+
+      const isConfused = confusionIndicators.some((indicator) =>
+        lastMessage.toLowerCase().includes(indicator)
+      );
+
+      // The AI should either remember context or ask specifically about which server
+      // (not be generally confused)
+      if (isConfused) {
+        // If confused, it should be asking specifically about which server
+        expect(
+          lastMessage.toLowerCase().includes('which') ||
+          lastMessage.toLowerCase().includes('server')
+        ).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -34,7 +34,12 @@
     "validate:standalone:headed": "playwright test standalone-validation.spec.ts --headed",
     "validate:integration": "playwright test integration.spec.ts",
     "validate:integration:headed": "playwright test integration.spec.ts --headed",
-    "validate:integration:debug": "playwright test integration.spec.ts --debug"
+    "validate:integration:debug": "playwright test integration.spec.ts --debug",
+    "e2e:core-features": "playwright test --project=core-features",
+    "e2e:core-features:headed": "playwright test --project=core-features --headed",
+    "e2e:core-features:debug": "playwright test --project=core-features --debug",
+    "e2e:core-features:mocked": "playwright test --project=core-features --grep 'Mocked'",
+    "e2e:core-features:real": "playwright test --project=core-features --grep 'Real API'"
   },
   "dependencies": {
     "@angular/animations": "^20.3.1",

--- a/packages/frontend/playwright.config.ts
+++ b/packages/frontend/playwright.config.ts
@@ -84,6 +84,22 @@ export default defineConfig({
       use: { ...devices['iPhone 12'] },
     },
 
+    /**
+     * Core Features Tests (Layer 5)
+     *
+     * Tests chat, AI responses, and MCP server generation.
+     * Uses real Claude API calls - costs money!
+     *
+     * Run with: npm run e2e:core-features
+     */
+    {
+      name: 'core-features',
+      testMatch: /core-features\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+      timeout: 300000, // 5 minutes per test for AI generation
+      retries: 0, // No retries - costs money
+    },
+
     /* Test against branded browsers. */
     // {
     //   name: 'Microsoft Edge',


### PR DESCRIPTION
## Summary

Implements end-to-end tests for chat, AI responses, and MCP server generation per Issue #91. Uses a **hybrid approach** to balance cost and coverage:

- **Tests 5.1-5.3**: Mocked backend (fast, free, reliable)
- **Tests 5.4-5.9**: Real Claude API (validates actual AI behavior)

## Changes

- **Extended IntegrationBackend** with `CoreFeaturesBackend` class:
  - `isAIReady()` - Check if AI services are ready
  - `collectSSEEvents()` - Subscribe and collect SSE events until complete
  - `waitForPhase()` - Wait for specific LangGraph phase
  - `sendAndWaitForGeneration()` - Send message and wait for complete

- **Extended ChatPage** page object with generation methods:
  - `waitForGenerationComplete()` - Wait for download button
  - `waitForProgressPhase()` - Track LangGraph phases
  - `hasDownloadZipButton()` / `clickDownloadZip()` - Download interaction
  - `isClarificationBeingAsked()` - Detect clarification requests

- **Created core-features.spec.ts** with 9 test cases:
  | Test | Mode | Description |
  |------|------|-------------|
  | 5.1 | Mocked | Send message and shows in chat |
  | 5.2 | Mocked | Receives streaming AI response |
  | 5.3 | Mocked | Responds to help request quickly |
  | 5.4 | Real | Generates MCP server from GitHub URL |
  | 5.5 | Real | Downloads generated code as ZIP |
  | 5.6 | Real | Handles service name input |
  | 5.7 | Real | Handles natural language description |
  | 5.8 | Real | Asks for clarification on vague input |
  | 5.9 | Real | Maintains conversation context |

- **Added Playwright project** `core-features` with 5-minute timeout

- **Added npm scripts**:
  - `npm run e2e:core-features` - All tests
  - `npm run e2e:core-features:mocked` - Fast, free tests only
  - `npm run e2e:core-features:real` - Real API tests only
  - `npm run e2e:core-features:headed` - See browser
  - `npm run e2e:core-features:debug` - Debug mode

## Test Plan

- [ ] Run mocked tests: `npm run e2e:core-features:mocked`
- [ ] Run real API tests (requires backend + ANTHROPIC_API_KEY): `npm run e2e:core-features:real`
- [ ] Verify tests pass in headed mode: `npm run e2e:core-features:headed`

## Cost Considerations

- Mocked tests (5.1-5.3): Free
- Real API tests (5.4-5.9): ~$0.001-0.01 per test
- Full suite: ~$0.05-0.10 total
- Run time: ~10-15 minutes total

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)