### PR TITLE
docs(testing): Add Session 1 infrastructure test results

### DIFF
--- a/docs/testing/session-1-results.md
+++ b/docs/testing/session-1-results.md
@@ -1,0 +1,80 @@
+# Session 1 Results: Infrastructure & Backend Testing
+
+**Date:** 2025-12-04
+**Issue:** #105
+**Status:** PASSED
+
+## Test Results Summary
+
+| Step | Description | Status | Notes |
+|------|-------------|--------|-------|
+| 1 | Check Prerequisites | PASS | Node.js v20.19.0, npm 10.8.2, Docker 28.4.0 |
+| 2 | Install Dependencies | PASS | 1833 packages installed, 0 vulnerabilities |
+| 3 | Start PostgreSQL | PASS | Container `mcp-everything-postgres` running |
+| 4 | Verify Database Connection | PASS | SELECT 1 succeeded |
+| 5 | Check Environment Variables | PASS | .env configured with required vars |
+| 6 | Build Backend | PASS | `nest build` completed with 0 errors |
+| 7 | Run Database Migrations | PASS | TypeORM synchronize created all tables |
+| 8 | Start Backend Server | PASS | Nest application started on port 3000 |
+| 9 | Test Health Endpoints | PASS | All endpoints responding correctly |
+
+## Detailed Results
+
+### Prerequisites
+```
+Node.js: v20.19.0
+npm: 10.8.2
+Docker: 28.4.0
+```
+
+### Database Tables Created
+TypeORM automatically created the following tables:
+- `users`
+- `conversations`
+- `conversation_memories`
+- `deployments`
+- `subscriptions`
+- `usage_records`
+- `hosted_servers`
+
+### Health Endpoints Tested
+
+| Endpoint | Response | Status |
+|----------|----------|--------|
+| `/health` | `{"status":"ok","timestamp":"...","service":"mcp-everything-backend"}` | 200 |
+| `/api/chat/health` | `{"status":"ok","timestamp":"...","activeSessions":0}` | 200 |
+| `/api/conversations` | `{"conversations":[]}` | 200 |
+| `/api/chat/stream/test-session` | SSE connection established | OK |
+
+### Warnings (Non-blocking)
+1. **Stripe not configured**: `STRIPE_SECRET_KEY not configured - Stripe features will be disabled`
+2. **GHCR not configured**: `GHCR_OWNER not configured - GHCR login skipped`
+
+These are expected in development environment.
+
+## Session 1 Complete Checklist
+
+- [x] Node/npm versions correct
+- [x] Docker running
+- [x] Dependencies installed
+- [x] PostgreSQL running
+- [x] Database connection works
+- [x] Environment variables set
+- [x] Backend builds
+- [x] Migrations run (via synchronize)
+- [x] Backend starts without errors
+- [x] Health endpoints respond
+
+## Bugs Found
+
+**None** - All tests passed successfully.
+
+## Notes
+
+1. The docker-compose.yml uses `postgres` as user/password (not `mcp` as mentioned in issue #105 steps)
+2. Database uses TypeORM `synchronize: true` mode, so explicit migrations are not needed
+3. The init-db.sql script runs on first container startup to create extensions
+
+## Next Steps
+
+Proceed to **Session 2 (#107)** - Frontend & Integration Testing


### PR DESCRIPTION
## Summary

- Executed Session 1 testing (Infrastructure & Backend) as defined in #105
- All 9 test steps passed successfully
- Documented results in `docs/testing/session-1-results.md`

## Test Results

| Step | Description | Status |
|------|-------------|--------|
| 1 | Check Prerequisites | PASS |
| 2 | Install Dependencies | PASS |
| 3 | Start PostgreSQL | PASS |
| 4 | Verify Database Connection | PASS |
| 5 | Check Environment Variables | PASS |
| 6 | Build Backend | PASS |
| 7 | Run Database Migrations | PASS |
| 8 | Start Backend Server | PASS |
| 9 | Test Health Endpoints | PASS |

## Health Endpoints Verified

- `/health` - Returns OK status
- `/api/chat/health` - Returns OK with active sessions count
- `/api/conversations` - Returns empty array
- `/api/chat/stream/:sessionId` - SSE connection works

## Notes

- Minor documentation correction: docker-compose uses `postgres` user/password, not `mcp`
- No bugs found during this session
- Ready to proceed to Session 2 (#107)

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)