### PR TITLE
fix: Resolve Session 4 bugs from Issue #86

### DIFF
--- a/packages/backend/src/chat/conversation.controller.ts
+++ b/packages/backend/src/chat/conversation.controller.ts
@@ -172,11 +172,19 @@ export class ConversationController {
    * Generate a title from conversation content
    */
   private generateTitle(conversation: any): string {
-    const messages = Array.isArray(conversation.messages) ? conversation.messages : [];
-    if (messages.length > 0) {
-      const firstMessage = messages[0].content || '';
-      return firstMessage.substring(0, 50) + (firstMessage.length > 50 ? '...' : '');
+    // First check if title is stored in state metadata
+    if (conversation.state?.metadata?.title) {
+      return conversation.state.metadata.title;
     }
+
+    // Fall back to deriving from first user message
+    const messages = Array.isArray(conversation.messages) ? conversation.messages : [];
+    const firstUserMessage = messages.find((m: any) => m.role === 'user');
+    if (firstUserMessage) {
+      const content = firstUserMessage.content || '';
+      return content.substring(0, 50) + (content.length > 50 ? '...' : '');
+    }
+
     return 'New conversation';
   }
 

--- a/packages/backend/src/orchestration/research.service.ts
+++ b/packages/backend/src/orchestration/research.service.ts
@@ -434,7 +434,7 @@ Return ONLY valid JSON:
     const services = await this.identifyServicesFromIntent(intent, keywords);
 
     if (services.length === 0) {
-      // No clear services identified, return low-confidence research
+      // No clear services identified, use synthesized confidence (dynamic, not hardcoded)
       const webSearch = await this.webSearchAgent(state, keywords.join(' '));
       const synthesized = await this.synthesizeResearch({
         webSearch,
@@ -446,7 +446,7 @@ Return ONLY valid JSON:
         webSearchFindings: webSearch,
         githubDeepDive: undefined, // No GitHub repo identified
         synthesizedPlan: synthesized,
-        researchConfidence: 0.3, // Low confidence
+        researchConfidence: synthesized.confidence, // Use dynamic confidence from synthesis
         researchIterations: 1,
       };
     }

--- a/packages/frontend/src/app/shared/components/conversation-sidebar/conversation-sidebar.component.html
+++ b/packages/frontend/src/app/shared/components/conversation-sidebar/conversation-sidebar.component.html
@@ -52,10 +52,22 @@
         <button
           mat-icon-button
           class="conversation-menu"
+          [matMenuTriggerFor]="conversationMenu"
           (click)="$event.stopPropagation()"
           matTooltip="More options">
           <mat-icon>more_vert</mat-icon>
         </button>
+
+        <mat-menu #conversationMenu="matMenu">
+          <button mat-menu-item (click)="onRenameConversation($event, conversation)">
+            <mat-icon>edit</mat-icon>
+            <span>Rename</span>
+          </button>
+          <button mat-menu-item (click)="onDeleteConversation($event, conversation.id)">
+            <mat-icon>delete</mat-icon>
+            <span>Delete</span>
+          </button>
+        </mat-menu>
       </div>
 
       <div *ngIf="conversations.length === 0" class="empty-state">

--- a/packages/frontend/src/app/shared/components/conversation-sidebar/conversation-sidebar.component.ts
+++ b/packages/frontend/src/app/shared/components/conversation-sidebar/conversation-sidebar.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
 import { sidebarAnimations } from '../../animations/sidebar.animations';
 
 interface Conversation {
@@ -20,7 +21,8 @@ interface Conversation {
     CommonModule,
     MatIconModule,
     MatButtonModule,
-    MatTooltipModule
+    MatTooltipModule,
+    MatMenuModule
   ],
   templateUrl: './conversation-sidebar.component.html',
   styleUrls: ['./conversation-sidebar.component.scss'],
@@ -32,6 +34,8 @@ export class ConversationSidebarComponent {
   @Output() close = new EventEmitter<void>();
   @Output() newChat = new EventEmitter<void>();
   @Output() selectConversation = new EventEmitter<string>();
+  @Output() deleteConversation = new EventEmitter<string>();
+  @Output() renameConversation = new EventEmitter<{id: string, title: string}>();
 
   constructor(private router: Router) {}
 
@@ -66,5 +70,18 @@ export class ConversationSidebarComponent {
     if (hours < 24) return `${hours}h ago`;
     if (days < 7) return `${days}d ago`;
     return new Date(timestamp).toLocaleDateString();
+  }
+
+  onDeleteConversation(event: Event, conversationId: string): void {
+    event.stopPropagation();
+    this.deleteConversation.emit(conversationId);
+  }
+
+  onRenameConversation(event: Event, conversation: Conversation): void {
+    event.stopPropagation();
+    const newTitle = prompt('Enter new title:', conversation.title);
+    if (newTitle && newTitle.trim() !== conversation.title) {
+      this.renameConversation.emit({ id: conversation.id, title: newTitle.trim() });
+    }
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes 5 bugs identified during Session 4 testing documented in Issue #86:

- **Message persistence (Critical)**: Messages now persist to database with `saveMessageToConversation()` helper
- **Clarification loop (Critical)**: Added missing `case 'clarify':` route + dynamic confidence instead of hardcoded 0.3
- **Context menu (Major)**: Added `MatMenuModule` and connected mat-menu for Rename/Delete functionality
- **Conversation titles (Minor)**: Auto-generate title from first user message, stored in `state.metadata.title`
- **Timestamps (Minor)**: `updatedAt` now updates when messages are saved, showing correct relative time

## Test plan

All fixes were manually verified with Playwright browser automation:

- [x] Send message → verify it persists in database and reloads on page refresh
- [x] Send vague request → receive clarification → provide details → verify flow proceeds to research/generation
- [x] Click "more_vert" button → verify Rename/Delete menu appears
- [x] Send first message → verify conversation title updates from "New conversation" to message content
- [x] Wait after sending message → verify timestamp shows "3m ago" instead of "Just now"

## Files Changed

| File | Change |
|------|--------|
| `graph.service.ts` | Added message persistence + clarify route |
| `research.service.ts` | Changed hardcoded 0.3 to dynamic confidence |
| `conversation-sidebar.component.ts` | Added MatMenuModule + event handlers |
| `conversation-sidebar.component.html` | Added mat-menu element |
| `conversation.controller.ts` | Updated generateTitle() to use metadata |

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)