### PR TITLE
fix: Return descriptive error message when no files to deploy (#121)

### DIFF
--- a/packages/backend/src/deployment/deployment.service.ts
+++ b/packages/backend/src/deployment/deployment.service.ts
@@ -29,6 +29,7 @@ import {
 import {
   DeploymentErrorCode,
   ERROR_RETRY_CONFIG,
+  ERROR_USER_MESSAGES,
   RetryStrategy,
 } from './types/deployment-errors.types';
 
@@ -104,7 +105,27 @@ export class DeploymentOrchestratorService {
       const files = await this.getGeneratedFiles(conversationId);
 
       if (files.length === 0) {
-        throw new Error('No generated files found for this conversation');
+        // Update deployment record with failure - no files to deploy
+        await this.deploymentRepository.update(savedDeployment.id, {
+          status: 'failed',
+          errorMessage: ERROR_USER_MESSAGES[DeploymentErrorCode.NO_FILES_TO_DEPLOY],
+          deployedAt: new Date(),
+          metadata: {
+            ...(savedDeployment.metadata || {}),
+            errorCode: DeploymentErrorCode.NO_FILES_TO_DEPLOY,
+            retryStrategy: ERROR_RETRY_CONFIG[DeploymentErrorCode.NO_FILES_TO_DEPLOY].strategy,
+          } as Record<string, any>,
+        });
+
+        return {
+          success: false,
+          deploymentId: savedDeployment.id,
+          type: 'repo',
+          urls: {},
+          error: ERROR_USER_MESSAGES[DeploymentErrorCode.NO_FILES_TO_DEPLOY],
+          errorCode: DeploymentErrorCode.NO_FILES_TO_DEPLOY,
+          retryStrategy: ERROR_RETRY_CONFIG[DeploymentErrorCode.NO_FILES_TO_DEPLOY].strategy,
+        };
       }
 
       const serverName = options.serverName || this.getServerName(conversation);
@@ -228,7 +249,27 @@ export class DeploymentOrchestratorService {
       const files = await this.getGeneratedFiles(conversationId);
 
       if (files.length === 0) {
-        throw new Error('No generated files found for this conversation');
+        // Update deployment record with failure - no files to deploy
+        await this.deploymentRepository.update(savedDeployment.id, {
+          status: 'failed',
+          errorMessage: ERROR_USER_MESSAGES[DeploymentErrorCode.NO_FILES_TO_DEPLOY],
+          deployedAt: new Date(),
+          metadata: {
+            ...(savedDeployment.metadata || {}),
+            errorCode: DeploymentErrorCode.NO_FILES_TO_DEPLOY,
+            retryStrategy: ERROR_RETRY_CONFIG[DeploymentErrorCode.NO_FILES_TO_DEPLOY].strategy,
+          } as Record<string, any>,
+        });
+
+        return {
+          success: false,
+          deploymentId: savedDeployment.id,
+          type: 'gist',
+          urls: {},
+          error: ERROR_USER_MESSAGES[DeploymentErrorCode.NO_FILES_TO_DEPLOY],
+          errorCode: DeploymentErrorCode.NO_FILES_TO_DEPLOY,
+          retryStrategy: ERROR_RETRY_CONFIG[DeploymentErrorCode.NO_FILES_TO_DEPLOY].strategy,
+        };
       }
 
       // Extract tools from conversation state


### PR DESCRIPTION
## Summary
- Fixes the "An unexpected error occurred" message shown when attempting to deploy a generated MCP server that has no files
- Returns proper `NO_FILES_TO_DEPLOY` error code with user-friendly message: "No files to deploy. Please generate the server first."
- Applies to both GitHub repository and Gist deployment methods

## Root Cause
When deployment failed due to no generated files, the backend was throwing a generic `Error` which got parsed as `UNKNOWN_ERROR` by the retry service, resulting in the generic error message being shown instead of the more helpful message.

## Changes
- Modified `deployment.service.ts` to return a proper `DeploymentResult` with the `NO_FILES_TO_DEPLOY` error code instead of throwing a generic error
- Added `ERROR_USER_MESSAGES` import to use the existing user-friendly message
- Both `deployToGitHub` and `deployToGist` methods now handle the no-files case gracefully

## Test plan
- [ ] Attempt to deploy when no MCP server has been generated - should see "No files to deploy. Please generate the server first."
- [ ] Verify TypeScript compiles without errors
- [ ] Verify backend builds successfully

Closes #121
Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)