### PR TITLE
fix: Use correct MCP SDK server startup pattern (#123)

### DIFF
--- a/packages/backend/src/testing/TESTING.md
+++ b/packages/backend/src/testing/TESTING.md
@@ -474,7 +474,7 @@ docker logs <container-id>
 **Common causes**:
 - Missing MCP dependencies in package.json
 - Invalid TypeScript in generated code
-- Missing server.run() call
+- Missing server.connect(transport) call in async main() function
 
 ### Issue: Tools/call returns error
 

--- a/packages/backend/src/testing/testing.fixtures.ts
+++ b/packages/backend/src/testing/testing.fixtures.ts
@@ -111,8 +111,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-const transport = new StdioServerTransport();
-server.run();
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch(console.error);
 `,
 
   packageJson: JSON.stringify(
@@ -216,8 +220,12 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   return { tools: [] };
 });
 
-const transport = new StdioServerTransport();
-server.run();
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch(console.error);
 `,
 
   packageJson: JSON.stringify(
@@ -276,7 +284,7 @@ server.run();
 };
 
 /**
- * Server with incomplete implementation (missing server.run())
+ * Server with incomplete implementation (missing server.connect() call)
  */
 export const FIXTURE_INCOMPLETE_SERVER: GeneratedCode = {
   mainFile: `import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -302,7 +310,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
   return { tools: [] };
 });
 
-// Missing server.run() call - server won't start
+// Missing server.connect(transport) call - server won't start
 `,
 
   packageJson: JSON.stringify(


### PR DESCRIPTION
## Summary
- Updates all code generation prompts to use `await server.connect(transport)` instead of non-existent `server.run()` method
- Fixes test fixtures to use correct async main() startup pattern
- Updates documentation and validation checks to match correct SDK API

## Root Cause
The MCP SDK v1.x uses `server.connect(transport)` within an async main function, but our prompts and fixtures were generating code with `server.run()` which doesn't exist in the SDK. This caused generated servers to fail at startup, resulting in 0/N tools passing validation.

## Changes
1. **mcp-generation.service.ts**: Updated all prompt templates to use correct startup pattern:
   ```typescript
   async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
   }
   main().catch(console.error);
   ```
2. **testing.fixtures.ts**: Updated FIXTURE_SIMPLE_WORKING_SERVER and other fixtures with correct startup
3. **TESTING.md**: Updated troubleshooting documentation

## Test Plan
- [ ] Verify TypeScript compilation passes
- [ ] Generate a new MCP server and verify tools work
- [ ] Check that validation now correctly detects `server.connect()` instead of `server.run()`

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)