### PR TITLE
fix: Hide cloud hosting button when no deployment exists (#124)

### DIFF
--- a/packages/frontend/src/app/features/chat/chat.component.html
+++ b/packages/frontend/src/app/features/chat/chat.component.html
@@ -105,6 +105,7 @@
                 Download ZIP
               </button>
               <button mat-raised-button
+                      *ngIf="latestDeployment?.status === 'success'"
                       (click)="openHostOnCloudModal(message)"
                       [disabled]="isDeploying(message) || isCloudDeploying()"
                       class="deploy-button cloud-button">

--- a/packages/frontend/src/app/features/chat/components/server-card/server-card.component.html
+++ b/packages/frontend/src/app/features/chat/components/server-card/server-card.component.html
@@ -41,6 +41,7 @@
     <button
       mat-raised-button
       color="primary"
+      *ngIf="hasSuccessfulDeployment"
       (click)="onHostOnCloud()"
       [disabled]="isDeploying"
       class="host-button"

--- a/packages/frontend/src/app/features/chat/components/server-card/server-card.component.ts
+++ b/packages/frontend/src/app/features/chat/components/server-card/server-card.component.ts
@@ -44,6 +44,7 @@ export class ServerCardComponent {
   @Input() envVars: ServerEnvVar[] = [];
   @Input() conversationId = '';
   @Input() isDeploying = false;
+  @Input() hasSuccessfulDeployment = false;
 
   @Output() download = new EventEmitter<void>();
   @Output() hostOnCloud = new EventEmitter<void>();


### PR DESCRIPTION
## Summary
- Hide "Host on Cloud" button when no successful deployment exists
- Add conditional rendering to only show the button when `latestDeployment?.status === 'success'`
- Add `hasSuccessfulDeployment` input property to server-card component for reusable pattern

## Problem
The "Host on Cloud" button was visible and clickable even when no deployment had been created, leading to a confusing error message: "No deployment available for hosting"

## Solution
Added `*ngIf` conditionals to:
1. `chat.component.html` - Check `latestDeployment?.status === 'success'`
2. `server-card.component.html` - Check `hasSuccessfulDeployment` input

## Test plan
- [ ] Generate an MCP server - button should NOT appear
- [ ] Deploy the server to GitHub/Gist successfully - button should appear
- [ ] Click "Host on Cloud" - should open modal (not show error)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)