### PR TITLE
fix: Sync generated code state to conversation and filesystem (#128)

### DIFF
--- a/packages/backend/src/database/entities/conversation.entity.ts
+++ b/packages/backend/src/database/entities/conversation.entity.ts
@@ -31,6 +31,11 @@ export class Conversation {
     intent?: string;
     extractedData?: Record<string, any>;
     metadata?: Record<string, any>;
+    // FIX #128: Add fields for generated code state sync
+    generatedCode?: any;
+    serverName?: string;
+    tools?: Array<{ name: string; description: string }>;
+    [key: string]: any; // Allow additional dynamic properties
   };
 
   @Column({ type: 'varchar', length: 100, nullable: true })

--- a/packages/backend/src/orchestration/types.ts
+++ b/packages/backend/src/orchestration/types.ts
@@ -61,9 +61,20 @@ export interface GraphState {
   // Code generation
   generatedCode?: {
     mainFile: string;
+    packageJson?: string;
+    tsConfig?: string;
     supportingFiles: Record<string, string>;
     tests?: string;
     documentation?: string;
+    metadata?: {
+      tools: Array<{
+        name: string;
+        description?: string;
+        inputSchema?: any;
+      }>;
+      iteration: number;
+      serverName: string;
+    };
   };
 
   // Execution and validation


### PR DESCRIPTION
## Summary
- Fix critical deployment issue where "No files to deploy" error occurs even after successful code generation
- Sync generated code from LangGraph checkpoints to `conversations.state` table
- Write generated files to filesystem for deployment service to read

## Root Cause
The LangGraph workflow saved checkpoints to `conversation_memories` table, but:
1. Deployment service reads from `conversations.state` (which remained empty)
2. Deployment service reads files from `generated-servers/{conversationId}/` (which were never written for non-GitHub-URL generations)

## Changes
1. **graph.service.ts**:
   - Added `syncGeneratedCodeToConversation()` to persist generated code to `conversations.state`
   - Added `writeGeneratedFilesToDisk()` to write files to `generated-servers/{conversationId}/`
   - Call both methods when graph completes with `isComplete: true` and `generatedCode`

2. **types.ts**:
   - Extended `GraphState.generatedCode` type to include `packageJson`, `tsConfig`, and `metadata` fields

3. **conversation.entity.ts**:
   - Extended state type to include `generatedCode`, `serverName`, and `tools` fields

## Test plan
- [ ] Generate an MCP server from a service name (e.g., "Create a Stripe MCP server")
- [ ] Verify files are written to `generated-servers/{conversationId}/`
- [ ] Verify "Deploy as Gist" works
- [ ] Verify "Deploy as Repo" works
- [ ] Verify ZIP download still works

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)