### PR TITLE
fix: Add zod and axios dependencies to generated package.json (#129)

### DIFF
--- a/packages/backend/src/mcp-generation.service.ts
+++ b/packages/backend/src/mcp-generation.service.ts
@@ -588,6 +588,8 @@ export class McpGenerationService {
         },
         dependencies: {
           '@modelcontextprotocol/sdk': '^0.5.0',
+          'zod': '^3.23.0',
+          'axios': '^1.7.0',
         },
         devDependencies: {
           '@types/node': '^20.0.0',

--- a/packages/backend/src/orchestration/refinement.service.ts
+++ b/packages/backend/src/orchestration/refinement.service.ts
@@ -399,6 +399,8 @@ Start with imports.`;
         },
         dependencies: {
           '@modelcontextprotocol/sdk': '^0.5.0',
+          'zod': '^3.23.0',
+          'axios': '^1.7.0',
         },
         devDependencies: {
           '@types/node': '^20.0.0',


### PR DESCRIPTION
## Summary
- Adds `zod ^3.23.0` and `axios ^1.7.0` to the generated package.json dependencies
- Fixes build failures caused by missing modules when generated MCP servers use these packages

## Root Cause
The code generation prompts instruct the LLM to use `zod` for validation and `axios` for HTTP requests, but the `generatePackageJson` methods in both `mcp-generation.service.ts` and `refinement.service.ts` did not include these as dependencies.

## Changes
- Updated `generatePackageJson` in `mcp-generation.service.ts` to include zod and axios
- Updated `generatePackageJson` in `refinement.service.ts` to include zod and axios

## Test plan
- [ ] Generate an MCP server that uses HTTP calls
- [ ] Download the generated ZIP
- [ ] Run `npm install && npm run build` - should succeed without missing module errors

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)