### PR TITLE
fix: Persist conversation messages and state to main table (#130)

### DIFF
--- a/packages/backend/src/chat/conversation.controller.ts
+++ b/packages/backend/src/chat/conversation.controller.ts
@@ -38,6 +38,7 @@ export class ConversationController {
 
   /**
    * Get a single conversation by ID
+   * FIX #130: Include state field for frontend to access generatedCode
    */
   @Get(':id')
   async getConversation(@Param('id') id: string) {
@@ -51,6 +52,8 @@ export class ConversationController {
         sessionId: conversation.sessionId,
         createdAt: conversation.createdAt,
         updatedAt: conversation.updatedAt,
+        // FIX #130: Include state for generatedCode access
+        state: conversation.state,
       },
     };
   }

--- a/packages/frontend/src/app/core/services/conversation.service.ts
+++ b/packages/frontend/src/app/core/services/conversation.service.ts
@@ -4,6 +4,31 @@ import { Observable, throwError, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 
+/**
+ * Conversation state that may contain generated code
+ * FIX #130: Added to support state persistence
+ */
+export interface ConversationState {
+  generatedCode?: {
+    mainFile?: string;
+    packageJson?: string;
+    tsConfig?: string;
+    supportingFiles?: Record<string, string>;
+    metadata?: {
+      serverName?: string;
+      tools?: Array<{ name: string; description: string }>;
+    };
+  };
+  serverName?: string;
+  tools?: Array<{ name: string; description: string }>;
+  metadata?: {
+    title?: string;
+    generatedAt?: string;
+    toolCount?: number;
+  };
+  [key: string]: unknown;
+}
+
 export interface Conversation {
   id: string;
   title: string;
@@ -12,6 +37,8 @@ export interface Conversation {
   sessionId?: string;
   createdAt?: Date;
   updatedAt?: Date;
+  // FIX #130: Include state for generatedCode access after refresh
+  state?: ConversationState;
 }
 
 export interface ConversationMessage {


### PR DESCRIPTION
## Summary
- Fixes conversation messages and state not being persisted to the main `conversations` table
- Uses `save()` instead of `update()` for reliable JSONB column persistence
- Exposes `state` field in conversation API response for frontend access

## Changes
- **Backend (`graph.service.ts`)**: Changed `saveMessageToConversation()` and `syncGeneratedCodeToConversation()` to use TypeORM `save()` instead of `update()` for JSONB columns
- **Backend (`conversation.controller.ts`)**: Added `state` field to `GET /api/conversations/:id` response
- **Frontend (`conversation.service.ts`)**: Added `ConversationState` interface for type safety

## Root Cause
TypeORM's `update()` method can have issues with complex JSONB column updates, causing the data to not persist properly. Using `save()` after modifying the entity directly is more reliable.

## Test plan
- [ ] Create a new conversation and send a message
- [ ] Verify messages are saved to `conversations.messages` in database
- [ ] Generate an MCP server
- [ ] Verify `generatedCode` is saved to `conversations.state` in database
- [ ] Refresh the page
- [ ] Verify deployment buttons appear (they read from `state.generatedCode`)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)