### PR TITLE
fix: Make sidebar header sticky so 'New chat' button is always visible (#131)

### DIFF
--- a/packages/frontend/src/app/shared/components/conversation-sidebar/conversation-sidebar.component.scss
+++ b/packages/frontend/src/app/shared/components/conversation-sidebar/conversation-sidebar.component.scss
@@ -40,6 +40,11 @@
 
 // Header
 .sidebar-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background-color: #f9f9f9;
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -194,6 +199,7 @@
 
 // Footer
 .sidebar-footer {
+  flex-shrink: 0;
   border-top: 1px solid #e5e5e5;
   padding: 8px;
 


### PR DESCRIPTION
## Summary
- Makes the sidebar header sticky so the "New chat" button remains visible on all screen sizes
- Adds `flex-shrink: 0` to both header and footer to prevent compression in the flexbox layout

## Changes
- `position: sticky` with `top: 0` and `z-index: 1` for the header
- `background-color: #f9f9f9` to prevent content showing through when scrolling
- `flex-shrink: 0` on both header and footer

## Test plan
- [ ] Open the sidebar with 10+ conversations
- [ ] Resize browser to various screen sizes (especially smaller heights like 600px)
- [ ] Verify "New chat" button remains visible in viewport
- [ ] Verify Settings button in footer remains at bottom
- [ ] Test Playwright automation can click the "New chat" button

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)