### PR TITLE
fix: Enable streaming for all LLM instances to fix 'Streaming is required' error (#142)

### DIFF
--- a/packages/backend/src/orchestration/clarification.service.ts
+++ b/packages/backend/src/orchestration/clarification.service.ts
@@ -45,12 +45,14 @@ export class ClarificationService {
 
   constructor(private readonly envVariableService: EnvVariableService) {
     // Initialize Claude Haiku for gap detection and question formulation
+    // streaming: true is required by the Anthropic API configuration (Issue #142)
     this.llm = new ChatAnthropic({
       modelName: 'claude-haiku-4-5-20251001',
       temperature: 0.7,
       topP: undefined, // Fix for @langchain/anthropic bug sending top_p: -1
       maxTokens: 8000, // Generous limit for clarification questions
       anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+      streaming: true,
     });
   }
 

--- a/packages/backend/src/orchestration/ensemble.service.ts
+++ b/packages/backend/src/orchestration/ensemble.service.ts
@@ -47,12 +47,14 @@ export class EnsembleService {
   constructor() {
     // Initialize Claude Haiku for all agents
     // Claude Haiku 4.5 supports up to 64K output tokens - use 8192 for agent responses
+    // streaming: true is required by the Anthropic API configuration (Issue #142)
     this.llm = new ChatAnthropic({
       modelName: 'claude-haiku-4-5-20251001',
       temperature: 0.7,
       topP: undefined, // Fix for @langchain/anthropic bug sending top_p: -1
       maxTokens: 8192, // Generous limit for tool recommendations
       anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+      streaming: true,
     });
 
     // Load agent prompts (async in constructor workaround - init in onModuleInit)

--- a/packages/backend/src/orchestration/refinement.service.ts
+++ b/packages/backend/src/orchestration/refinement.service.ts
@@ -158,23 +158,27 @@ export class RefinementService {
     private readonly mcpGenerationService: McpGenerationService,
   ) {
     // Initialize Claude Haiku for failure analysis
+    // streaming: true is required by the Anthropic API configuration (Issue #142)
     this.llm = new ChatAnthropic({
       modelName: 'claude-haiku-4-5-20251001',
       temperature: 0.7,
       topP: undefined, // Fix for @langchain/anthropic bug sending top_p: -1
       maxTokens: 16000, // Generous limit for detailed failure analysis
       anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+      streaming: true,
     });
 
     // Separate LLM instance for code generation with maximum token limit
     // Claude Haiku 4.5 supports up to 64K output tokens
     // This prevents truncation of generated TypeScript files (Issue #136)
+    // streaming: true is required by the Anthropic API configuration (Issue #142)
     this.codeGenLlm = new ChatAnthropic({
       modelName: 'claude-haiku-4-5-20251001',
       temperature: 0.3, // Lower temperature for more consistent code output
       topP: undefined,
       maxTokens: 64000, // Maximum output for Haiku 4.5 - no truncation
       anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+      streaming: true,
     });
   }
 

--- a/packages/backend/src/orchestration/research.service.ts
+++ b/packages/backend/src/orchestration/research.service.ts
@@ -67,12 +67,14 @@ export class ResearchService {
     // private readonly researchCacheService: ResearchCacheService, // TODO: Implement caching
   ) {
     // Initialize Claude Haiku for cost-effective research synthesis
+    // streaming: true is required by the Anthropic API configuration (Issue #142)
     this.llm = new ChatAnthropic({
       modelName: 'claude-haiku-4-5-20251001',
       temperature: 0.7,
       topP: undefined, // Fix for @langchain/anthropic bug sending top_p: -1
       maxTokens: 16000, // Generous limit for research synthesis
       anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+      streaming: true,
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #142 - Code generation fails with 'Streaming is required' error.

The Anthropic API configuration requires streaming mode for LLM calls. The main `graph.service.ts` had `streaming: true` enabled, but the individual orchestration services that create their own ChatAnthropic instances were missing this setting.

## Changes

- **RefinementService**: Add `streaming: true` to both `llm` and `codeGenLlm` instances
- **EnsembleService**: Add `streaming: true` to `llm` instance
- **ResearchService**: Add `streaming: true` to `llm` instance
- **ClarificationService**: Add `streaming: true` to `llm` instance

## Root Cause

The `graph.service.ts` LLM was configured with `streaming: true`, but when the workflow reaches services like `RefinementService` that create their own LLM instances, those instances were using the default non-streaming mode. This caused the Anthropic API to reject the requests with "Streaming is required".

## Test plan

- [ ] Start backend server
- [ ] Send a message to generate an MCP server (e.g., "Create a simple calculator MCP server with add and multiply tools")
- [ ] Verify the workflow reaches the refinement phase without "Streaming is required" error
- [ ] Verify code generation completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)